### PR TITLE
Add initial Dockerfiles, configs, and GitHub workflows for Cloudberry

### DIFF
--- a/.github/workflows/docker-cbdb-build-containers.yml
+++ b/.github/workflows/docker-cbdb-build-containers.yml
@@ -1,0 +1,218 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Purpose: Builds, tests and pushes Docker images for Apache Cloudberry DB build environments
+# Images are built for Rocky Linux 8 and 9, tested with TestInfra, and pushed to DockerHub
+#
+# Images are tagged with:
+# - cbdb-build-rocky8-latest
+# - cbdb-build-rocky8-{YYYYMMDD}-{git-short-sha}
+# - cbdb-build-rocky9-latest
+# - cbdb-build-rocky9-{YYYYMMDD}-{git-short-sha}
+#
+# Features:
+# - Matrix build for multiple platforms
+# - Caching strategy for efficient builds
+# - Path filtering to only build changed platforms
+# - Comprehensive build summary and metadata
+# - Container testing with TestInfra
+
+name: docker-cbdb-build-containers
+
+# Trigger on pushes to docker-images branch when relevant paths change
+# Also allows manual triggering via GitHub UI
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'images/docker/cbdb/build/rocky8/**'
+      - 'images/docker/cbdb/build/rocky9/**'
+  workflow_dispatch:  # Manual trigger
+
+# Prevent multiple workflow runs from interfering with each other
+concurrency:
+  group: docker-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    timeout-minutes: 60  # Prevent hanging builds
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Build for both Rocky Linux 8 and 9
+        platform: ['rocky8', 'rocky9']
+
+    steps:
+      # Checkout repository code
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Generate version information for image tags
+      - name: Set version
+        id: version
+        run: |
+          echo "BUILD_DATE=$(date -u +'%Y%m%d')" >> $GITHUB_OUTPUT
+          echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      # Determine if the current platform's files have changed
+      - name: Determine if platform changed
+        id: platform-filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            rocky8:
+              - 'images/docker/cbdb/build/rocky8/**'
+            rocky9:
+              - 'images/docker/cbdb/build/rocky9/**'
+
+      # Skip if no changes for current platform
+      - name: Skip if not relevant
+        if: ${{ steps.platform-filter.outputs[matrix.platform] != 'true' }}
+        run: echo "Skipping because the changes do not affect this platform"
+
+      # Login to DockerHub for pushing images
+      - name: Login to Docker Hub
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Setup Docker Buildx for efficient builds
+      - name: Set up Docker Buildx
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' }}
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
+
+      # Build the Docker image locally for testing
+      - name: Build Docker image for cbdb-build-${{ matrix.platform }}
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ./images/docker/cbdb/build/${{ matrix.platform }}
+          push: false  # Don't push yet, we'll test first
+          load: true   # Load into local Docker daemon for testing
+          # Use caching for faster builds
+          cache-from: |
+            type=registry,ref=${{ secrets.DOCKERHUB_USER }}/cbdb-build-${{ matrix.platform }}:latest
+            type=gha,scope=docker-cbdb-build-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=docker-cbdb-build-${{ matrix.platform }}
+          tags: |
+            cbdb-build-${{ matrix.platform }}:latest
+          # Add metadata labels for better image tracking
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.version.outputs.BUILD_DATE }}
+            org.opencontainers.image.version=${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}
+
+      # Show available Docker images
+      - name: List Docker images
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' }}
+        run: docker images
+
+      # Run TestInfra tests against the built image
+      - name: Run Testinfra Tests
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' }}
+        id: test
+        run: |
+          docker run -d \
+                     -h cdw \
+                     --name cbdb-build-${{ matrix.platform }}-test \
+                     cbdb-build-${{ matrix.platform }}:latest \
+                     bash \
+                     -c "sleep 30"
+          docker exec cbdb-build-${{ matrix.platform }}-test pytest \
+                     --cache-clear \
+                     --disable-warnings \
+                     -p no:warnings \
+                     /tests/testinfra/test_cloudberry_db_env.py
+
+      # Save test results as artifacts
+      - name: Save test results
+        if: always() && steps.platform-filter.outputs[matrix.platform] == 'true'
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results-${{ matrix.platform }}
+          path: |
+            test-results/
+          retention-days: 7
+
+      # Cleanup test container
+      - name: Remove Test Container
+        if: always() && steps.platform-filter.outputs[matrix.platform] == 'true'
+        run: docker rm -f cbdb-build-${{ matrix.platform }}-test
+
+      # Push the image to DockerHub if tests passed
+      - name: Retag and Push Docker image to DockerHub
+        if: steps.test.outcome == 'success' && steps.platform-filter.outputs[matrix.platform] == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: ./images/docker/cbdb/build/${{ matrix.platform }}
+          push: true
+          cache-from: |
+            type=registry,ref=${{ secrets.DOCKERHUB_USER }}/cbdb-build-${{ matrix.platform }}:latest
+            type=gha,scope=docker-cbdb-build-${{ matrix.platform }}
+          tags: |
+            ${{ secrets.DOCKERHUB_USER }}/incubator-cloudberry:cbdb-build-${{ matrix.platform }}-latest
+            ${{ secrets.DOCKERHUB_USER }}/incubator-cloudberry:cbdb-build-${{ matrix.platform }}-${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.version.outputs.BUILD_DATE }}
+            org.opencontainers.image.version=${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}
+
+      # Generate build summary
+      - name: Build Summary
+        if: always()
+        run: |
+          echo "### Build Summary for ${{ matrix.platform }} 🚀" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "#### 🔍 Build Information" >> $GITHUB_STEP_SUMMARY
+          echo "- **Build Status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Platform**: ${{ matrix.platform }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit SHA**: [\`${{ github.sha }}\`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})" >> $GITHUB_STEP_SUMMARY
+          echo "- **Trigger**: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch**: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Build Date**: ${{ steps.version.outputs.BUILD_DATE }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version Tag**: \`${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [[ "${{ steps.test.outcome }}" == "success" && "${{ steps.platform-filter.outputs[matrix.platform] }}" == "true" ]]; then
+            echo "#### 🐳 Docker Image" >> $GITHUB_STEP_SUMMARY
+            echo "- **Repository**: [\`${{ secrets.DOCKERHUB_USER }}/cbdb-build-${{ matrix.platform }}\`](https://hub.docker.com/r/${{ secrets.DOCKERHUB_USER }}/cbdb-build-${{ matrix.platform }})" >> $GITHUB_STEP_SUMMARY
+            echo "- **Tags Pushed**:" >> $GITHUB_STEP_SUMMARY
+            echo "  - \`latest\`" >> $GITHUB_STEP_SUMMARY
+            echo "  - \`${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+
+            echo "#### 📋 Quick Reference" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+            echo "# Pull the image" >> $GITHUB_STEP_SUMMARY
+            echo "docker pull ${{ secrets.DOCKERHUB_USER }}/cbdb-build-${{ matrix.platform }}:${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "# View image details" >> $GITHUB_STEP_SUMMARY
+            echo "docker inspect ${{ secrets.DOCKERHUB_USER }}/cbdb-build-${{ matrix.platform }}:${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/docker-cbdb-test-containers.yml
+++ b/.github/workflows/docker-cbdb-test-containers.yml
@@ -1,0 +1,180 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Purpose: Builds, tests and pushes Docker images for Apache Cloudberry DB test environments
+# Images are built for Rocky Linux 8 and 9, tested with TestInfra, and pushed to DockerHub
+#
+# Images are tagged with:
+# - cbdb-test-rocky8-latest
+# - cbdb-test-rocky8-{YYYYMMDD}-{git-short-sha}
+# - cbdb-test-rocky9-latest
+# - cbdb-test-rocky9-{YYYYMMDD}-{git-short-sha}
+#
+# Features:
+# - Matrix build for multiple platforms
+# - Caching strategy for efficient builds
+# - Path filtering to only build changed platforms
+# - Comprehensive build summary and metadata
+
+name: docker-cbdb-test-containers
+
+# Trigger on pushes to docker-images branch when relevant paths change
+# Also allows manual triggering via GitHub UI
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'images/docker/cbdb/test/rocky8/**'
+      - 'images/docker/cbdb/test/rocky9/**'
+  workflow_dispatch:  # Manual trigger
+
+# Prevent multiple workflow runs from interfering with each other
+concurrency:
+  group: docker-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    timeout-minutes: 60  # Prevent hanging builds
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Build for both Rocky Linux 8 and 9
+        platform: ['rocky8', 'rocky9']
+
+    steps:
+      # Checkout repository code
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Generate version information for image tags
+      - name: Set version
+        id: version
+        run: |
+          echo "BUILD_DATE=$(date -u +'%Y%m%d')" >> $GITHUB_OUTPUT
+          echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      # Determine if the current platform's files have changed
+      - name: Determine if platform changed
+        id: platform-filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            rocky8:
+              - 'images/docker/cbdb/test/rocky8/**'
+            rocky9:
+              - 'images/docker/cbdb/test/rocky9/**'
+
+      # Skip if no changes for current platform
+      - name: Skip if not relevant
+        if: ${{ steps.platform-filter.outputs[matrix.platform] != 'true' }}
+        run: echo "Skipping because the changes do not affect this platform"
+
+      # Login to DockerHub for pushing images
+      - name: Login to Docker Hub
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Setup Docker Buildx for efficient builds
+      - name: Set up Docker Buildx
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' }}
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
+
+      # Build the Docker image locally for testing
+      - name: Build Docker image for cbdb-test-${{ matrix.platform }}
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ./images/docker/cbdb/test/${{ matrix.platform }}
+          push: false  # Don't push yet, we'll test first
+          load: true   # Load into local Docker daemon for testing
+          # Use caching for faster builds
+          cache-from: |
+            type=registry,ref=${{ secrets.DOCKERHUB_USER }}/cbdb-test-${{ matrix.platform }}:latest
+            type=gha,scope=docker-cbdb-test-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=docker-cbdb-test-${{ matrix.platform }}
+          tags: |
+            cbdb-test-${{ matrix.platform }}:latest
+          # Add metadata labels for better image tracking
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.version.outputs.BUILD_DATE }}
+            org.opencontainers.image.version=${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}
+
+      # Push the image to DockerHub if tests passed
+      - name: Retag and Push Docker image to DockerHub
+        if: steps.platform-filter.outputs[matrix.platform] == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: ./images/docker/cbdb/test/${{ matrix.platform }}
+          push: true
+          cache-from: |
+            type=registry,ref=${{ secrets.DOCKERHUB_USER }}/cbdb-test-${{ matrix.platform }}:latest
+            type=gha,scope=docker-cbdb-test-${{ matrix.platform }}
+          tags: |
+            ${{ secrets.DOCKERHUB_USER }}/incubator-cloudberry:cbdb-test-${{ matrix.platform }}-latest
+            ${{ secrets.DOCKERHUB_USER }}/incubator-cloudberry:cbdb-test-${{ matrix.platform }}-${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.version.outputs.BUILD_DATE }}
+            org.opencontainers.image.version=${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}
+
+      # Generate build summary
+      - name: Build Summary
+        if: always()
+        run: |
+          echo "### Build Summary for ${{ matrix.platform }} 🚀" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "#### 🔍 Build Information" >> $GITHUB_STEP_SUMMARY
+          echo "- **Build Status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Platform**: ${{ matrix.platform }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit SHA**: [\`${{ github.sha }}\`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})" >> $GITHUB_STEP_SUMMARY
+          echo "- **Trigger**: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch**: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Build Date**: ${{ steps.version.outputs.BUILD_DATE }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version Tag**: \`${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [[ "${{ steps.platform-filter.outputs[matrix.platform] }}" == "true" ]]; then
+            echo "#### 🐳 Docker Image" >> $GITHUB_STEP_SUMMARY
+            echo "- **Repository**: [\`${{ secrets.DOCKERHUB_USER }}/cbdb-test-${{ matrix.platform }}\`](https://hub.docker.com/r/${{ secrets.DOCKERHUB_USER }}/cbdb-test-${{ matrix.platform }})" >> $GITHUB_STEP_SUMMARY
+            echo "- **Tags Pushed**:" >> $GITHUB_STEP_SUMMARY
+            echo "  - \`latest\`" >> $GITHUB_STEP_SUMMARY
+            echo "  - \`${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+
+            echo "#### 📋 Quick Reference" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+            echo "# Pull the image" >> $GITHUB_STEP_SUMMARY
+            echo "docker pull ${{ secrets.DOCKERHUB_USER }}/cbdb-test-${{ matrix.platform }}:${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "# View image details" >> $GITHUB_STEP_SUMMARY
+            echo "docker inspect ${{ secrets.DOCKERHUB_USER }}/cbdb-test-${{ matrix.platform }}:${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/images/docker/cbdb/build/rocky8/Dockerfile
+++ b/images/docker/cbdb/build/rocky8/Dockerfile
@@ -1,0 +1,196 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Apache Cloudberry (incubating) is an effort undergoing incubation at
+# the Apache Software Foundation (ASF), sponsored by the Apache
+# Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a
+# further review indicates that the infrastructure, communications,
+# and decision making process have stabilized in a manner consistent
+# with other successful ASF projects.
+#
+# While incubation status is not necessarily a reflection of the
+# completeness or stability of the code, it does indicate that the
+# project has yet to be fully endorsed by the ASF.
+#
+# --------------------------------------------------------------------
+# Dockerfile for Apache Cloudberry Build Environment
+# --------------------------------------------------------------------
+# This Dockerfile sets up a Rocky Linux 9-based container for building
+# and developing Apache Cloudberry. It installs necessary system
+# utilities, development tools, and configures the environment for SSH
+# access and systemd support.
+#
+# Key Features:
+# - Locale setup for en_US.UTF-8
+# - SSH daemon setup for remote access
+# - Essential development tools and libraries installation
+# - User configuration for 'gpadmin' with sudo privileges
+#
+# Usage:
+#   docker build -t cloudberry-db-env .
+#   docker run -h cdw -it cloudberry-db-env
+# --------------------------------------------------------------------
+
+# Base image: Rocky Linux 8
+FROM rockylinux/rockylinux:8
+
+# Argument for configuring the timezone
+ARG TIMEZONE_VAR="America/Los_Angeles"
+
+# Environment variables for locale and user
+ENV container=docker
+ENV LANG=en_US.UTF-8
+ENV USER=gpadmin
+
+# --------------------------------------------------------------------
+# Install Development Tools and Utilities
+# --------------------------------------------------------------------
+# Install various development tools, system utilities, and libraries
+# required for building and running Apache Cloudberry.
+# - EPEL repository is enabled for additional packages.
+# - Cleanup steps are added to reduce image size after installation.
+# --------------------------------------------------------------------
+RUN dnf makecache && \
+    dnf install -y \
+        epel-release \
+        git && \
+    dnf makecache && \
+    dnf config-manager --disable epel && \
+    dnf install -y -d0 --enablerepo=epel \
+        the_silver_searcher \
+        htop && \
+    dnf install -y -d0 \
+        apr-devel \
+        autoconf \
+        bison \
+        bzip2-devel \
+        diffutils \
+        flex \
+        gcc \
+        gcc-c++ \
+        glibc-langpack-en \
+        glibc-locale-source \
+        iproute \
+        java-11-openjdk \
+        java-11-openjdk-devel \
+        krb5-devel \
+        libcurl-devel \
+        libevent-devel \
+        libuuid-devel \
+        libxml2-devel \
+        libzstd-devel \
+        lz4 \
+        lz4-devel \
+        make \
+        m4 \
+        nc \
+        net-tools \
+        openldap-devel \
+        openssh-clients \
+        openssh-server \
+        openssl-devel \
+        pam-devel \
+        passwd \
+        perl-Env \
+        perl-ExtUtils-Embed \
+        perl-Test-Simple \
+        procps-ng \
+        python3 \
+        python3-devel \
+        readline-devel \
+        rsync \
+        sshpass \
+        sudo \
+        tar \
+        unzip \
+        util-linux-ng \
+        wget \
+        which \
+        zlib-devel && \
+    dnf install -y -d0 --enablerepo=devel \
+        libuv-devel \
+        libyaml-devel \
+        perl-IPC-Run && \
+    dnf clean all && \
+    cd && XERCES_LATEST_RELEASE=3.3.0 && \
+    wget -nv "https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-${XERCES_LATEST_RELEASE}.tar.gz" && \
+    echo "$(curl -sL https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-${XERCES_LATEST_RELEASE}.tar.gz.sha256)" | sha256sum -c - && \
+    tar xf "xerces-c-${XERCES_LATEST_RELEASE}.tar.gz"; rm "xerces-c-${XERCES_LATEST_RELEASE}.tar.gz" && \
+    cd xerces-c-${XERCES_LATEST_RELEASE} && \
+    ./configure --prefix=/usr/local/xerces-c && \
+    make -j$(nproc) && \
+    make install -C ~/xerces-c-${XERCES_LATEST_RELEASE} && \
+    rm -rf ~/xerces-c* && \
+    cd && GO_VERSION="go1.23.2" && \
+    GO_SHA256="542d3c1705f1c6a1c5a80d5dc62e2e45171af291e755d591c5e6531ef63b454e" && \
+    GO_URL="https://go.dev/dl/${GO_VERSION}.linux-amd64.tar.gz" && \
+    wget -nv "${GO_URL}" && \
+    echo "${GO_SHA256}  ${GO_VERSION}.linux-amd64.tar.gz" | sha256sum -c - && \
+    tar xf "${GO_VERSION}.linux-amd64.tar.gz" && \
+    mv go "/usr/local/${GO_VERSION}" && \
+    ln -s "/usr/local/${GO_VERSION}" /usr/local/go && \
+    rm -f "${GO_VERSION}.linux-amd64.tar.gz" && \
+    echo 'export PATH=$PATH:/usr/local/go/bin' | tee -a /etc/profile.d/go.sh > /dev/null
+
+# --------------------------------------------------------------------
+# Copy Configuration Files and Setup the Environment
+# --------------------------------------------------------------------
+# - Copy custom configuration files from the build context to /tmp/.
+# - Apply custom system limits and timezone.
+# - Create and configure the 'gpadmin' user with sudo privileges.
+# - Set up SSH for password-based authentication.
+# - Generate locale and set the default locale to en_US.UTF-8.
+# --------------------------------------------------------------------
+COPY ./configs/* /tmp/
+
+RUN cp /tmp/90-cbdb-limits /etc/security/limits.d/90-cbdb-limits && \
+    sed -i.bak -r 's/^(session\s+required\s+pam_limits.so)/#\1/' /etc/pam.d/* && \
+    cat /usr/share/zoneinfo/${TIMEZONE_VAR} > /etc/localtime && \
+    chmod 777 /tmp/init_system.sh && \
+    /usr/sbin/groupadd gpadmin && \
+    /usr/sbin/useradd gpadmin -g gpadmin -G wheel && \
+    setcap cap_net_raw+ep /usr/bin/ping && \
+    echo 'gpadmin ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/90-gpadmin && \
+    echo -e '\n# Add Cloudberry entries\nif [ -f /usr/local/cbdb/greenplum_path.sh ]; then\n  source /usr/local/cbdb/greenplum_path.sh\nfi' >> /home/gpadmin/.bashrc && \
+    ssh-keygen -A && \
+    echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config && \
+    localedef -i en_US -f UTF-8 en_US.UTF-8 && \
+    echo "LANG=en_US.UTF-8" | tee /etc/locale.conf && \
+    dnf clean all  # Final cleanup to remove unnecessary files
+
+# Install testinfra via pip
+RUN pip3 install pytest-testinfra
+
+# Example: Copying test files into the container
+COPY tests /tests
+
+# --------------------------------------------------------------------
+# Set the Default User and Command
+# --------------------------------------------------------------------
+# The default user is set to 'gpadmin', and the container starts by
+# running the init_system.sh script. The container also mounts the
+# /sys/fs/cgroup volume for systemd compatibility.
+# --------------------------------------------------------------------
+USER gpadmin
+
+VOLUME [ "/sys/fs/cgroup" ]
+CMD ["bash","-c","/tmp/init_system.sh"]

--- a/images/docker/cbdb/build/rocky8/configs/90-cbdb-limits
+++ b/images/docker/cbdb/build/rocky8/configs/90-cbdb-limits
@@ -1,0 +1,32 @@
+# /etc/security/limits.d/90-db-limits
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+
+# Core dump file size limits for gpadmin
+gpadmin soft core unlimited
+gpadmin hard core unlimited
+
+# Open file limits for gpadmin
+gpadmin soft nofile 524288
+gpadmin hard nofile 524288
+
+# Process limits for gpadmin
+gpadmin soft nproc 131072
+gpadmin hard nproc 131072

--- a/images/docker/cbdb/build/rocky8/configs/gpinitsystem.conf
+++ b/images/docker/cbdb/build/rocky8/configs/gpinitsystem.conf
@@ -1,0 +1,87 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+# gpinitsystem Configuration File for Apache Cloudberry
+# --------------------------------------------------------------------
+# This configuration file is used to initialize an Apache Cloudberry
+# cluster. It defines the settings for the coordinator, primary segments,
+# and mirrors, as well as other important configuration options.
+# --------------------------------------------------------------------
+
+# Segment prefix - This prefix is used for naming the segment directories.
+# For example, the primary segment directories will be named gpseg0, gpseg1, etc.
+SEG_PREFIX=gpseg
+
+# Coordinator port - The port number where the coordinator will listen.
+# This is the port used by clients to connect to the database.
+COORDINATOR_PORT=5432
+
+# Coordinator hostname - The hostname of the machine where the coordinator
+# will be running. The $(hostname) command will automatically insert the
+# hostname of the current machine.
+COORDINATOR_HOSTNAME=$(hostname)
+
+# Coordinator data directory - The directory where the coordinator's data
+# will be stored. This directory should have enough space to store metadata
+# and system catalogs.
+COORDINATOR_DIRECTORY=/data1/coordinator
+
+# Base port for primary segments - The starting port number for the primary
+# segments. Each primary segment will use a unique port number starting from
+# this base.
+PORT_BASE=6000
+
+# Primary segment data directories - An array specifying the directories where
+# the primary segment data will be stored. Each directory corresponds to a
+# primary segment. In this case, two primary segments will be created in the
+# same directory.
+declare -a DATA_DIRECTORY=(/data1/primary /data1/primary)
+
+# Base port for mirror segments - The starting port number for the mirror
+# segments. Each mirror segment will use a unique port number starting from
+# this base.
+MIRROR_PORT_BASE=7000
+
+# Mirror segment data directories - An array specifying the directories where
+# the mirror segment data will be stored. Each directory corresponds to a
+# mirror segment. In this case, two mirror segments will be created in the
+# same directory.
+declare -a MIRROR_DATA_DIRECTORY=(/data1/mirror /data1/mirror)
+
+# Trusted shell - The shell program used for remote execution. Cloudberry uses
+# SSH to run commands on other machines in the cluster. 'ssh' is the default.
+TRUSTED_SHELL=ssh
+
+# Database encoding - The character set encoding to be used by the database.
+# 'UNICODE' is a common choice, especially for internationalization.
+ENCODING=UNICODE
+
+# Default database name - The name of the default database to be created during
+# initialization. This is also the default database that the gpadmin user will
+# connect to.
+DATABASE_NAME=gpadmin
+
+# Machine list file - A file containing the list of hostnames where the primary
+# segments will be created. Each line in the file represents a different machine.
+# This file is critical for setting up the cluster across multiple nodes.
+MACHINE_LIST_FILE=/home/gpadmin/hostfile_gpinitsystem
+
+# --------------------------------------------------------------------
+# End of gpinitsystem Configuration File
+# --------------------------------------------------------------------

--- a/images/docker/cbdb/build/rocky8/configs/init_system.sh
+++ b/images/docker/cbdb/build/rocky8/configs/init_system.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+# --------------------------------------------------------------------
+# Container Initialization Script
+# --------------------------------------------------------------------
+# This script sets up the environment inside the Docker container for
+# the Apache Cloudberry Build Environment. It performs the following
+# tasks:
+#
+# 1. Verifies that the container is running with the expected hostname.
+# 2. Starts the SSH daemon to allow SSH access to the container.
+# 3. Configures passwordless SSH access for the 'gpadmin' user.
+# 4. Displays a welcome banner and system information.
+# 5. Starts an interactive bash shell.
+#
+# This script is intended to be used as an entrypoint or initialization
+# script for the Docker container.
+# --------------------------------------------------------------------
+
+# --------------------------------------------------------------------
+# Check if the hostname is 'cdw'
+# --------------------------------------------------------------------
+# The script checks if the container's hostname is set to 'cdw'. This is
+# a requirement for this environment, and if the hostname does not match,
+# the script will exit with an error message. This ensures consistency
+# across different environments.
+# --------------------------------------------------------------------
+if [ "$(hostname)" != "cdw" ]; then
+    echo "Error: This container must be run with the hostname 'cdw'."
+    echo "Use the following command: docker run -h cdw ..."
+    exit 1
+fi
+
+# --------------------------------------------------------------------
+# Start SSH daemon and setup for SSH access
+# --------------------------------------------------------------------
+# The SSH daemon is started to allow remote access to the container via
+# SSH. This is useful for development and debugging purposes. If the SSH
+# daemon fails to start, the script exits with an error.
+# --------------------------------------------------------------------
+if ! sudo /usr/sbin/sshd; then
+    echo "Failed to start SSH daemon" >&2
+    exit 1
+fi
+
+# --------------------------------------------------------------------
+# Remove /run/nologin to allow logins
+# --------------------------------------------------------------------
+# The /run/nologin file, if present, prevents users from logging into
+# the system. This file is removed to ensure that users can log in via SSH.
+# --------------------------------------------------------------------
+sudo rm -rf /run/nologin
+
+# --------------------------------------------------------------------
+# Configure passwordless SSH access for 'gpadmin' user
+# --------------------------------------------------------------------
+# The script sets up SSH key-based authentication for the 'gpadmin' user,
+# allowing passwordless SSH access. It generates a new SSH key pair if one
+# does not already exist, and configures the necessary permissions.
+# --------------------------------------------------------------------
+mkdir -p /home/gpadmin/.ssh
+chmod 700 /home/gpadmin/.ssh
+
+if [ ! -f /home/gpadmin/.ssh/id_rsa ]; then
+    ssh-keygen -t rsa -b 4096 -C gpadmin -f /home/gpadmin/.ssh/id_rsa -P "" > /dev/null 2>&1
+fi
+
+cat /home/gpadmin/.ssh/id_rsa.pub >> /home/gpadmin/.ssh/authorized_keys
+chmod 600 /home/gpadmin/.ssh/authorized_keys
+
+# Add the container's hostname to the known_hosts file to avoid SSH warnings
+ssh-keyscan -t rsa cdw > /home/gpadmin/.ssh/known_hosts 2>/dev/null
+
+# Change to the home directory of the current user
+cd $HOME
+
+# --------------------------------------------------------------------
+# Display a Welcome Banner
+# --------------------------------------------------------------------
+# The following ASCII art and welcome message are displayed when the
+# container starts. This banner provides a visual indication that the
+# container is running in the Apache Cloudberry Build Environment.
+# --------------------------------------------------------------------
+cat <<-'EOF'
+
+======================================================================
+
+                          ++++++++++       ++++++
+                        ++++++++++++++   +++++++
+                       ++++        +++++ ++++
+                      ++++          +++++++++
+                   =+====         =============+
+                 ========       =====+      =====
+                ====  ====     ====           ====
+               ====    ===     ===             ====
+               ====            === ===         ====
+               ====            ===  ==--       ===
+                =====          ===== --       ====
+                 =====================     ======
+                   ============================
+                                     =-----=
+     ____  _                    _  _
+    / ___|| |  ___   _   _   __| || |__    ___  _ __  _ __  _   _
+   | |    | | / _ \ | | | | / _` || '_ \  / _ \| '__|| '__|| | | |
+   | |___ | || (_) || |_| || (_| || |_) ||  __/| |   | |   | |_| |
+    \____||_| \____  \__,_| \__,_||_.__/  \___||_|   |_|    \__, |
+                                                            |___/
+----------------------------------------------------------------------
+
+EOF
+
+# --------------------------------------------------------------------
+# Display System Information
+# --------------------------------------------------------------------
+# The script sources the /etc/os-release file to retrieve the operating
+# system name and version. It then displays the following information:
+# - OS name and version
+# - Current user
+# - Container hostname
+# - IP address
+# - CPU model name and number of cores
+# - Total memory available
+# This information is useful for users to understand the environment they
+# are working in.
+# --------------------------------------------------------------------
+source /etc/os-release
+
+cat <<-EOF
+Welcome to the Apache Cloudberry Build Environment!
+
+Container OS ........ : $NAME $VERSION
+User ................ : $(whoami)
+Container hostname .. : $(hostname)
+IP Address .......... : $(hostname -I | awk '{print $1}')
+CPU Info ............ : $(lscpu | grep 'Model name:' | awk '{print substr($0, index($0,$3))}')
+CPU(s) .............. : $(nproc)
+Memory .............. : $(free -h | grep Mem: | awk '{print $2}') total
+======================================================================
+
+EOF
+
+# --------------------------------------------------------------------
+# Start an interactive bash shell
+# --------------------------------------------------------------------
+# Finally, the script starts an interactive bash shell to keep the
+# container running and allow the user to interact with the environment.
+# --------------------------------------------------------------------
+/bin/bash

--- a/images/docker/cbdb/build/rocky8/tests/requirements.txt
+++ b/images/docker/cbdb/build/rocky8/tests/requirements.txt
@@ -1,0 +1,3 @@
+testinfra
+pytest-testinfra
+paramiko

--- a/images/docker/cbdb/build/rocky8/tests/testinfra/test_cloudberry_db_env.py
+++ b/images/docker/cbdb/build/rocky8/tests/testinfra/test_cloudberry_db_env.py
@@ -1,0 +1,126 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+
+import testinfra
+
+def test_installed_packages(host):
+    """
+    Test if the essential packages are installed.
+    """
+    packages = [
+        "epel-release",
+        "git",
+        "the_silver_searcher",
+        "htop",
+        "bison",
+        "gcc",
+        "gcc-c++",
+        "glibc-langpack-en",
+        "glibc-locale-source",
+        "openssh-clients",
+        "openssh-server",
+        "sudo",
+        "rsync",
+        "wget",
+        "openssl-devel",
+        "python36-devel",
+        "readline-devel",
+        "zlib-devel",
+        "libcurl-devel",
+        "libevent-devel",
+        "libxml2-devel",
+        "libuuid-devel",
+        "libzstd-devel",
+        "lz4",
+        "openldap-devel",
+        "libuv-devel",
+        "libyaml-devel"
+    ]
+    for package in packages:
+        pkg = host.package(package)
+        assert pkg.is_installed
+
+
+def test_user_gpadmin_exists(host):
+    """
+    Test if the gpadmin user exists and is configured properly.
+    """
+    user = host.user("gpadmin")
+    assert user.exists
+    assert "wheel" in user.groups
+
+
+def test_ssh_service(host):
+    """
+    Test if SSH service is configured correctly.
+    """
+    sshd_config = host.file("/etc/ssh/sshd_config")
+    assert sshd_config.exists
+
+
+def test_locale_configured(host):
+    """
+    Test if the locale is configured correctly.
+    """
+    locale_conf = host.file("/etc/locale.conf")
+    assert locale_conf.exists
+    assert locale_conf.contains("LANG=en_US.UTF-8")
+
+
+def test_timezone(host):
+    """
+    Test if the timezone is configured correctly.
+    """
+    localtime = host.file("/etc/localtime")
+    assert localtime.exists
+
+
+def test_system_limits_configured(host):
+    """
+    Test if the custom system limits are applied.
+    """
+    limits_file = host.file("/etc/security/limits.d/90-cbdb-limits")
+    assert limits_file.exists
+
+
+def test_init_system_script(host):
+    """
+    Test if the init_system.sh script is present and executable.
+    """
+    script = host.file("/tmp/init_system.sh")
+    assert script.exists
+    assert script.mode == 0o777
+
+
+def test_custom_configuration_files(host):
+    """
+    Test if custom configuration files are correctly copied.
+    """
+    config_file = host.file("/tmp/90-cbdb-limits")
+    assert config_file.exists
+
+
+def test_locale_generated(host):
+    """
+    Test if the en_US.UTF-8 locale is correctly generated.
+    """
+    locale = host.run("locale -a | grep en_US.utf8")
+    assert locale.exit_status == 0
+    assert "en_US.utf8" in locale.stdout

--- a/images/docker/cbdb/build/rocky9/Dockerfile
+++ b/images/docker/cbdb/build/rocky9/Dockerfile
@@ -1,0 +1,203 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Apache Cloudberry (incubating) is an effort undergoing incubation at
+# the Apache Software Foundation (ASF), sponsored by the Apache
+# Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a
+# further review indicates that the infrastructure, communications,
+# and decision making process have stabilized in a manner consistent
+# with other successful ASF projects.
+#
+# While incubation status is not necessarily a reflection of the
+# completeness or stability of the code, it does indicate that the
+# project has yet to be fully endorsed by the ASF.
+#
+# --------------------------------------------------------------------
+# Dockerfile for Apache Cloudberry Build Environment
+# --------------------------------------------------------------------
+# This Dockerfile sets up a Rocky Linux 9-based container for building
+# and developing Apache Cloudberry. It installs necessary system
+# utilities, development tools, and configures the environment for SSH
+# access and systemd support.
+#
+# Key Features:
+# - Locale setup for en_US.UTF-8
+# - SSH daemon setup for remote access
+# - Essential development tools and libraries installation
+# - User configuration for 'gpadmin' with sudo privileges
+#
+# Usage:
+#   docker build -t cloudberry-db-env .
+#   docker run -h cdw -it cloudberry-db-env
+# --------------------------------------------------------------------
+
+# Base image: Rocky Linux 9
+FROM rockylinux/rockylinux:9
+
+# Argument for configuring the timezone
+ARG TIMEZONE_VAR="America/Los_Angeles"
+
+# Environment variables for locale and user
+ENV container=docker
+ENV LANG=en_US.UTF-8
+ENV USER=gpadmin
+
+# --------------------------------------------------------------------
+# Install Development Tools and Utilities
+# --------------------------------------------------------------------
+# Install various development tools, system utilities, and libraries
+# required for building and running Apache Cloudberry.
+# - EPEL repository is enabled for additional packages.
+# - Cleanup steps are added to reduce image size after installation.
+# --------------------------------------------------------------------
+RUN dnf makecache && \
+    dnf install -y \
+        epel-release \
+        git && \
+    dnf config-manager --disable epel-cisco-openh264 && \
+    dnf makecache && \
+    dnf config-manager --disable epel && \
+    dnf install -y --enablerepo=epel \
+        the_silver_searcher \
+        bat \
+        htop && \
+    dnf install -y \
+        bison \
+        cmake3 \
+        ed \
+        flex \
+        gcc \
+        gcc-c++ \
+        glibc-langpack-en \
+        glibc-locale-source \
+        initscripts \
+        iproute \
+        less \
+        m4 \
+        net-tools \
+        openssh-clients \
+        openssh-server \
+        perl \
+        rpm-build \
+        rpmdevtools \
+        rsync \
+        sudo \
+        tar \
+        unzip \
+        util-linux-ng \
+        wget \
+        sshpass \
+        which && \
+    dnf install -y \
+        apr-devel \
+        bzip2-devel \
+        java-11-openjdk \
+        java-11-openjdk-devel \
+        krb5-devel \
+        libcurl-devel \
+        libevent-devel \
+        libxml2-devel \
+        libuuid-devel \
+        libzstd-devel \
+        lz4 \
+        lz4-devel \
+        openldap-devel \
+        openssl-devel \
+        pam-devel \
+        perl-ExtUtils-Embed \
+        perl-Test-Simple \
+        perl-core \
+        python3-devel \
+        python3-pytest \
+        readline-devel \
+        zlib-devel && \
+    dnf install -y --enablerepo=crb \
+        libuv-devel \
+        libyaml-devel \
+        perl-IPC-Run && \
+    dnf clean all && \
+    cd && XERCES_LATEST_RELEASE=3.3.0 && \
+    wget -nv "https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-${XERCES_LATEST_RELEASE}.tar.gz" && \
+    echo "$(curl -sL https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-${XERCES_LATEST_RELEASE}.tar.gz.sha256)" | sha256sum -c - && \
+    tar xf "xerces-c-${XERCES_LATEST_RELEASE}.tar.gz"; rm "xerces-c-${XERCES_LATEST_RELEASE}.tar.gz" && \
+    cd xerces-c-${XERCES_LATEST_RELEASE} && \
+    ./configure --prefix=/usr/local/xerces-c && \
+    make -j$(nproc) && \
+    make install -C ~/xerces-c-${XERCES_LATEST_RELEASE} && \
+    rm -rf ~/xerces-c* && \
+    cd && GO_VERSION="go1.23.2" && \
+    GO_VERSION="go1.23.2" && \
+    GO_SHA256="542d3c1705f1c6a1c5a80d5dc62e2e45171af291e755d591c5e6531ef63b454e" && \
+    GO_URL="https://go.dev/dl/${GO_VERSION}.linux-amd64.tar.gz" && \
+    wget -nv "${GO_URL}" && \
+    echo "${GO_SHA256}  ${GO_VERSION}.linux-amd64.tar.gz" | sha256sum -c - && \
+    tar xf "${GO_VERSION}.linux-amd64.tar.gz" && \
+    mv go "/usr/local/${GO_VERSION}" && \
+    ln -s "/usr/local/${GO_VERSION}" /usr/local/go && \
+    rm -f "${GO_VERSION}.linux-amd64.tar.gz" && \
+    echo 'export PATH=$PATH:/usr/local/go/bin' | tee -a /etc/profile.d/go.sh > /dev/null
+
+# --------------------------------------------------------------------
+# Copy Configuration Files and Setup the Environment
+# --------------------------------------------------------------------
+# - Copy custom configuration files from the build context to /tmp/.
+# - Apply custom system limits and timezone.
+# - Create and configure the 'gpadmin' user with sudo privileges.
+# - Set up SSH for password-based authentication.
+# - Generate locale and set the default locale to en_US.UTF-8.
+# --------------------------------------------------------------------
+
+# Copy configuration files from their respective locations
+COPY ./configs/* /tmp/
+
+RUN cp /tmp/90-cbdb-limits /etc/security/limits.d/90-cbdb-limits && \
+    sed -i.bak -r 's/^(session\s+required\s+pam_limits.so)/#\1/' /etc/pam.d/* && \
+    cat /usr/share/zoneinfo/${TIMEZONE_VAR} > /etc/localtime && \
+    chmod 777 /tmp/init_system.sh && \
+    /usr/sbin/groupadd gpadmin && \
+    /usr/sbin/useradd gpadmin -g gpadmin -G wheel && \
+    setcap cap_net_raw+ep /usr/bin/ping && \
+    echo 'gpadmin ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/90-gpadmin && \
+    echo -e '\n# Add Cloudberry entries\nif [ -f /usr/local/cbdb/greenplum_path.sh ]; then\n  source /usr/local/cbdb/greenplum_path.sh\nfi' >> /home/gpadmin/.bashrc && \
+    ssh-keygen -A && \
+    echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config && \
+    localedef -i en_US -f UTF-8 en_US.UTF-8 && \
+    echo "LANG=en_US.UTF-8" | tee /etc/locale.conf && \
+    dnf clean all  # Final cleanup to remove unnecessary files
+
+# Install testinfra via pip
+RUN pip3 install pytest-testinfra
+
+# Copying test files into the container
+COPY ./tests /tests
+
+# --------------------------------------------------------------------
+# Set the Default User and Command
+# --------------------------------------------------------------------
+# The default user is set to 'gpadmin', and the container starts by
+# running the init_system.sh script. The container also mounts the
+# /sys/fs/cgroup volume for systemd compatibility.
+# --------------------------------------------------------------------
+USER gpadmin
+
+VOLUME [ "/sys/fs/cgroup" ]
+CMD ["bash","-c","/tmp/init_system.sh"]

--- a/images/docker/cbdb/build/rocky9/configs/90-cbdb-limits
+++ b/images/docker/cbdb/build/rocky9/configs/90-cbdb-limits
@@ -1,0 +1,32 @@
+# /etc/security/limits.d/90-db-limits
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+
+# Core dump file size limits for gpadmin
+gpadmin soft core unlimited
+gpadmin hard core unlimited
+
+# Open file limits for gpadmin
+gpadmin soft nofile 524288
+gpadmin hard nofile 524288
+
+# Process limits for gpadmin
+gpadmin soft nproc 131072
+gpadmin hard nproc 131072

--- a/images/docker/cbdb/build/rocky9/configs/gpinitsystem.conf
+++ b/images/docker/cbdb/build/rocky9/configs/gpinitsystem.conf
@@ -1,0 +1,89 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+
+# --------------------------------------------------------------------
+# gpinitsystem Configuration File for Apache Cloudberry
+# --------------------------------------------------------------------
+# This configuration file is used to initialize an Apache Cloudberry
+# cluster. It defines the settings for the coordinator, primary segments,
+# and mirrors, as well as other important configuration options.
+# --------------------------------------------------------------------
+
+# Segment prefix - This prefix is used for naming the segment directories.
+# For example, the primary segment directories will be named gpseg0, gpseg1, etc.
+SEG_PREFIX=gpseg
+
+# Coordinator port - The port number where the coordinator will listen.
+# This is the port used by clients to connect to the database.
+COORDINATOR_PORT=5432
+
+# Coordinator hostname - The hostname of the machine where the coordinator
+# will be running. The $(hostname) command will automatically insert the
+# hostname of the current machine.
+COORDINATOR_HOSTNAME=$(hostname)
+
+# Coordinator data directory - The directory where the coordinator's data
+# will be stored. This directory should have enough space to store metadata
+# and system catalogs.
+COORDINATOR_DIRECTORY=/data1/coordinator
+
+# Base port for primary segments - The starting port number for the primary
+# segments. Each primary segment will use a unique port number starting from
+# this base.
+PORT_BASE=6000
+
+# Primary segment data directories - An array specifying the directories where
+# the primary segment data will be stored. Each directory corresponds to a
+# primary segment. In this case, two primary segments will be created in the
+# same directory.
+declare -a DATA_DIRECTORY=(/data1/primary /data1/primary)
+
+# Base port for mirror segments - The starting port number for the mirror
+# segments. Each mirror segment will use a unique port number starting from
+# this base.
+MIRROR_PORT_BASE=7000
+
+# Mirror segment data directories - An array specifying the directories where
+# the mirror segment data will be stored. Each directory corresponds to a
+# mirror segment. In this case, two mirror segments will be created in the
+# same directory.
+declare -a MIRROR_DATA_DIRECTORY=(/data1/mirror /data1/mirror)
+
+# Trusted shell - The shell program used for remote execution. Cloudberry uses
+# SSH to run commands on other machines in the cluster. 'ssh' is the default.
+TRUSTED_SHELL=ssh
+
+# Database encoding - The character set encoding to be used by the database.
+# 'UNICODE' is a common choice, especially for internationalization.
+ENCODING=UNICODE
+
+# Default database name - The name of the default database to be created during
+# initialization. This is also the default database that the gpadmin user will
+# connect to.
+DATABASE_NAME=gpadmin
+
+# Machine list file - A file containing the list of hostnames where the primary
+# segments will be created. Each line in the file represents a different machine.
+# This file is critical for setting up the cluster across multiple nodes.
+MACHINE_LIST_FILE=/home/gpadmin/hostfile_gpinitsystem
+
+# --------------------------------------------------------------------
+# End of gpinitsystem Configuration File
+# --------------------------------------------------------------------

--- a/images/docker/cbdb/build/rocky9/configs/init_system.sh
+++ b/images/docker/cbdb/build/rocky9/configs/init_system.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+## Container Initialization Script
+# --------------------------------------------------------------------
+## This script sets up the environment inside the Docker container for
+## the Apache Cloudberry Build Environment. It performs the following
+## tasks:
+##
+## 1. Verifies that the container is running with the expected hostname.
+## 2. Starts the SSH daemon to allow SSH access to the container.
+## 3. Configures passwordless SSH access for the 'gpadmin' user.
+## 4. Displays a welcome banner and system information.
+## 5. Starts an interactive bash shell.
+##
+## This script is intended to be used as an entrypoint or initialization
+## script for the Docker container.
+# --------------------------------------------------------------------
+
+# --------------------------------------------------------------------
+# Check if the hostname is 'cdw'
+# --------------------------------------------------------------------
+# The script checks if the container's hostname is set to 'cdw'. This is
+# a requirement for this environment, and if the hostname does not match,
+# the script will exit with an error message. This ensures consistency
+# across different environments.
+# --------------------------------------------------------------------
+if [ "$(hostname)" != "cdw" ]; then
+    echo "Error: This container must be run with the hostname 'cdw'."
+    echo "Use the following command: docker run -h cdw ..."
+    exit 1
+fi
+
+# --------------------------------------------------------------------
+# Start SSH daemon and setup for SSH access
+# --------------------------------------------------------------------
+# The SSH daemon is started to allow remote access to the container via
+# SSH. This is useful for development and debugging purposes. If the SSH
+# daemon fails to start, the script exits with an error.
+# --------------------------------------------------------------------
+if ! sudo /usr/sbin/sshd; then
+    echo "Failed to start SSH daemon" >&2
+    exit 1
+fi
+
+# --------------------------------------------------------------------
+# Remove /run/nologin to allow logins
+# --------------------------------------------------------------------
+# The /run/nologin file, if present, prevents users from logging into
+# the system. This file is removed to ensure that users can log in via SSH.
+# --------------------------------------------------------------------
+sudo rm -rf /run/nologin
+
+# --------------------------------------------------------------------
+# Configure passwordless SSH access for 'gpadmin' user
+# --------------------------------------------------------------------
+# The script sets up SSH key-based authentication for the 'gpadmin' user,
+# allowing passwordless SSH access. It generates a new SSH key pair if one
+# does not already exist, and configures the necessary permissions.
+# --------------------------------------------------------------------
+mkdir -p /home/gpadmin/.ssh
+chmod 700 /home/gpadmin/.ssh
+
+if [ ! -f /home/gpadmin/.ssh/id_rsa ]; then
+    ssh-keygen -t rsa -b 4096 -C gpadmin -f /home/gpadmin/.ssh/id_rsa -P "" > /dev/null 2>&1
+fi
+
+cat /home/gpadmin/.ssh/id_rsa.pub >> /home/gpadmin/.ssh/authorized_keys
+chmod 600 /home/gpadmin/.ssh/authorized_keys
+
+# Add the container's hostname to the known_hosts file to avoid SSH warnings
+ssh-keyscan -t rsa cdw > /home/gpadmin/.ssh/known_hosts 2>/dev/null
+
+# Change to the home directory of the current user
+cd $HOME
+
+# --------------------------------------------------------------------
+# Display a Welcome Banner
+# --------------------------------------------------------------------
+# The following ASCII art and welcome message are displayed when the
+# container starts. This banner provides a visual indication that the
+# container is running in the Apache Cloudberry Build Environment.
+# --------------------------------------------------------------------
+cat <<-'EOF'
+
+======================================================================
+
+                          ++++++++++       ++++++
+                        ++++++++++++++   +++++++
+                       ++++        +++++ ++++
+                      ++++          +++++++++
+                   =+====         =============+
+                 ========       =====+      =====
+                ====  ====     ====           ====
+               ====    ===     ===             ====
+               ====            === ===         ====
+               ====            ===  ==--       ===
+                =====          ===== --       ====
+                 =====================     ======
+                   ============================
+                                     =-----=
+     ____  _                    _  _
+    / ___|| |  ___   _   _   __| || |__    ___  _ __  _ __  _   _
+   | |    | | / _ \ | | | | / _` || '_ \  / _ \| '__|| '__|| | | |
+   | |___ | || (_) || |_| || (_| || |_) ||  __/| |   | |   | |_| |
+    \____||_| \____  \__,_| \__,_||_.__/  \___||_|   |_|    \__, |
+                                                            |___/
+----------------------------------------------------------------------
+
+EOF
+
+# --------------------------------------------------------------------
+# Display System Information
+# --------------------------------------------------------------------
+# The script sources the /etc/os-release file to retrieve the operating
+# system name and version. It then displays the following information:
+# - OS name and version
+# - Current user
+# - Container hostname
+# - IP address
+# - CPU model name and number of cores
+# - Total memory available
+# This information is useful for users to understand the environment they
+# are working in.
+# --------------------------------------------------------------------
+source /etc/os-release
+
+cat <<-EOF
+Welcome to the Apache Cloudberry Build Environment!
+
+Container OS ........ : $NAME $VERSION
+User ................ : $(whoami)
+Container hostname .. : $(hostname)
+IP Address .......... : $(hostname -I | awk '{print $1}')
+CPU Info ............ : $(lscpu | grep 'Model name:' | awk '{print substr($0, index($0,$3))}')
+CPU(s) .............. : $(nproc)
+Memory .............. : $(free -h | grep Mem: | awk '{print $2}') total
+======================================================================
+
+EOF
+
+# --------------------------------------------------------------------
+# Start an interactive bash shell
+# --------------------------------------------------------------------
+# Finally, the script starts an interactive bash shell to keep the
+# container running and allow the user to interact with the environment.
+# --------------------------------------------------------------------
+/bin/bash

--- a/images/docker/cbdb/build/rocky9/tests/requirements.txt
+++ b/images/docker/cbdb/build/rocky9/tests/requirements.txt
@@ -1,0 +1,3 @@
+testinfra
+pytest-testinfra
+paramiko

--- a/images/docker/cbdb/build/rocky9/tests/testinfra/test_cloudberry_db_env.py
+++ b/images/docker/cbdb/build/rocky9/tests/testinfra/test_cloudberry_db_env.py
@@ -1,0 +1,129 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+
+import testinfra
+
+def test_installed_packages(host):
+    """
+    Test if the essential packages are installed.
+    """
+    packages = [
+        "epel-release",
+        "git",
+        "the_silver_searcher",
+        "bat",
+        "htop",
+        "bison",
+        "cmake",
+        "gcc",
+        "gcc-c++",
+        "glibc-langpack-en",
+        "glibc-locale-source",
+        "openssh-clients",
+        "openssh-server",
+        "sudo",
+        "rsync",
+        "wget",
+        "openssl-devel",
+        "python3-devel",
+        "python3-pytest",
+        "readline-devel",
+        "zlib-devel",
+        "libcurl-devel",
+        "libevent-devel",
+        "libxml2-devel",
+        "libuuid-devel",
+        "libzstd-devel",
+        "lz4",
+        "openldap-devel",
+        "libuv-devel",
+        "libyaml-devel"
+    ]
+    for package in packages:
+        pkg = host.package(package)
+        assert pkg.is_installed
+
+
+def test_user_gpadmin_exists(host):
+    """
+    Test if the gpadmin user exists and is configured properly.
+    """
+    user = host.user("gpadmin")
+    assert user.exists
+    assert "wheel" in user.groups
+
+
+def test_ssh_service(host):
+    """
+    Test if SSH service is configured correctly.
+    """
+    sshd_config = host.file("/etc/ssh/sshd_config")
+    assert sshd_config.exists
+
+
+def test_locale_configured(host):
+    """
+    Test if the locale is configured correctly.
+    """
+    locale_conf = host.file("/etc/locale.conf")
+    assert locale_conf.exists
+    assert locale_conf.contains("LANG=en_US.UTF-8")
+
+
+def test_timezone(host):
+    """
+    Test if the timezone is configured correctly.
+    """
+    localtime = host.file("/etc/localtime")
+    assert localtime.exists
+
+
+def test_system_limits_configured(host):
+    """
+    Test if the custom system limits are applied.
+    """
+    limits_file = host.file("/etc/security/limits.d/90-cbdb-limits")
+    assert limits_file.exists
+
+
+def test_init_system_script(host):
+    """
+    Test if the init_system.sh script is present and executable.
+    """
+    script = host.file("/tmp/init_system.sh")
+    assert script.exists
+    assert script.mode == 0o777
+
+
+def test_custom_configuration_files(host):
+    """
+    Test if custom configuration files are correctly copied.
+    """
+    config_file = host.file("/tmp/90-cbdb-limits")
+    assert config_file.exists
+
+
+def test_locale_generated(host):
+    """
+    Test if the en_US.UTF-8 locale is correctly generated.
+    """
+    locale = host.run("locale -a | grep en_US.utf8")
+    assert locale.exit_status == 0
+    assert "en_US.utf8" in locale.stdout

--- a/images/docker/cbdb/test/rocky8/Dockerfile
+++ b/images/docker/cbdb/test/rocky8/Dockerfile
@@ -1,0 +1,133 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Apache Cloudberry (incubating) is an effort undergoing incubation at
+# the Apache Software Foundation (ASF), sponsored by the Apache
+# Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a
+# further review indicates that the infrastructure, communications,
+# and decision making process have stabilized in a manner consistent
+# with other successful ASF projects.
+#
+# While incubation status is not necessarily a reflection of the
+# completeness or stability of the code, it does indicate that the
+# project has yet to be fully endorsed by the ASF.
+#
+# --------------------------------------------------------------------
+# Dockerfile for Apache Cloudberry Base Environment
+# --------------------------------------------------------------------
+# This Dockerfile sets up a Rocky Linux 8-based container to serve as
+# a base environment for evaluating Apache Cloudberry. It installs
+# necessary system utilities, configures the environment for SSH access,
+# and sets up a 'gpadmin' user with sudo privileges. The Apache
+# Cloudberry RPM can be installed into this container for testing and
+# functional verification.
+#
+# Key Features:
+# - Locale setup for en_US.UTF-8
+# - SSH daemon setup for remote access
+# - Essential system utilities installation
+# - Separate user creation and configuration steps
+#
+# Security Considerations:
+# - This Dockerfile prioritizes ease of use for functional testing and
+#   evaluation. It includes configurations such as passwordless sudo access
+#   for the 'gpadmin' user and SSH access with password authentication.
+# - These configurations are suitable for testing and development but
+#   should NOT be used in a production environment due to potential security
+#   risks.
+#
+# Usage:
+#   docker build -t cloudberry-db-base-env .
+#   docker run -h cdw -it cloudberry-db-base-env
+# --------------------------------------------------------------------
+
+# Base image: Rocky Linux 8
+FROM rockylinux/rockylinux:8
+
+# Argument for configuring the timezone
+ARG TIMEZONE_VAR="America/Los_Angeles"
+
+# Environment variables for locale
+ENV LANG=en_US.UTF-8
+
+# --------------------------------------------------------------------
+# System Update and Installation
+# --------------------------------------------------------------------
+# Update the system and install essential system utilities required for
+# running and testing Apache Cloudberry. Cleanup the DNF cache afterward
+# to reduce the image size.
+# --------------------------------------------------------------------
+RUN dnf install -y \
+        glibc-locale-source \
+        make \
+        openssh \
+        openssh-clients \
+        openssh-server \
+        procps-ng \
+        sudo \
+        which \
+        && \
+    dnf clean all  # Clean up DNF cache after package installations
+
+# --------------------------------------------------------------------
+# User Creation and Configuration
+# --------------------------------------------------------------------
+# - Create the 'gpadmin' user and group.
+# - Configure the 'gpadmin' user with passwordless sudo privileges.
+# - Add Cloudberry-specific entries to the gpadmin's .bashrc.
+# --------------------------------------------------------------------
+RUN /usr/sbin/groupadd gpadmin && \
+    /usr/sbin/useradd gpadmin -g gpadmin -G wheel && \
+    echo 'gpadmin ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/90-gpadmin && \
+    echo -e '\n# Add Cloudberry entries\nif [ -f /usr/local/cloudberry/greenplum_path.sh ]; then\n  source /usr/local/cloudberry/greenplum_path.sh\n  export COORDINATOR_DATA_DIRECTORY=/data1/coordinator/gpseg-1\nfi' >> /home/gpadmin/.bashrc
+
+# --------------------------------------------------------------------
+# Copy Configuration Files and Setup the Environment
+# --------------------------------------------------------------------
+# - Copy custom configuration files from the build context to /tmp/.
+# - Apply custom system limits and timezone.
+# - Set up SSH for password-based authentication.
+# - Generate locale and set the default locale to en_US.UTF-8.
+# --------------------------------------------------------------------
+COPY ./configs/* /tmp/
+
+RUN cp /tmp/90-cbdb-limits /etc/security/limits.d/90-cbdb-limits && \
+    sed -i.bak -r 's/^(session\s+required\s+pam_limits.so)/#\1/' /etc/pam.d/* && \
+    cat /usr/share/zoneinfo/${TIMEZONE_VAR} > /etc/localtime && \
+    chmod 777 /tmp/init_system.sh && \
+    setcap cap_net_raw+ep /usr/bin/ping && \
+    ssh-keygen -A && \
+    echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config && \
+    localedef -i en_US -f UTF-8 en_US.UTF-8 && \
+    echo "LANG=en_US.UTF-8" | tee /etc/locale.conf
+
+# --------------------------------------------------------------------
+# Set the Default User and Command
+# --------------------------------------------------------------------
+# The default user is set to 'gpadmin', and the container starts by
+# running the init_system.sh script. This container serves as a base
+# environment, and the Apache Cloudberry RPM can be installed for
+# testing and functional verification.
+# --------------------------------------------------------------------
+USER gpadmin
+
+CMD ["bash","-c","/tmp/init_system.sh"]

--- a/images/docker/cbdb/test/rocky8/configs/90-cbdb-limits
+++ b/images/docker/cbdb/test/rocky8/configs/90-cbdb-limits
@@ -1,0 +1,32 @@
+# /etc/security/limits.d/90-db-limits
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+
+# Core dump file size limits for gpadmin
+gpadmin soft core unlimited
+gpadmin hard core unlimited
+
+# Open file limits for gpadmin
+gpadmin soft nofile 524288
+gpadmin hard nofile 524288
+
+# Process limits for gpadmin
+gpadmin soft nproc 131072
+gpadmin hard nproc 131072

--- a/images/docker/cbdb/test/rocky8/configs/gpinitsystem.conf
+++ b/images/docker/cbdb/test/rocky8/configs/gpinitsystem.conf
@@ -1,0 +1,87 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+# gpinitsystem Configuration File for Cloudberry Database
+# --------------------------------------------------------------------
+# This configuration file is used to initialize a Cloudberry Database
+# cluster. It defines the settings for the coordinator, primary segments,
+# and mirrors, as well as other important configuration options.
+# --------------------------------------------------------------------
+
+# Segment prefix - This prefix is used for naming the segment directories.
+# For example, the primary segment directories will be named gpseg0, gpseg1, etc.
+SEG_PREFIX=gpseg
+
+# Coordinator port - The port number where the coordinator will listen.
+# This is the port used by clients to connect to the database.
+COORDINATOR_PORT=5432
+
+# Coordinator hostname - The hostname of the machine where the coordinator
+# will be running. The $(hostname) command will automatically insert the
+# hostname of the current machine.
+COORDINATOR_HOSTNAME=$(hostname)
+
+# Coordinator data directory - The directory where the coordinator's data
+# will be stored. This directory should have enough space to store metadata
+# and system catalogs.
+COORDINATOR_DIRECTORY=/data1/coordinator
+
+# Base port for primary segments - The starting port number for the primary
+# segments. Each primary segment will use a unique port number starting from
+# this base.
+PORT_BASE=6000
+
+# Primary segment data directories - An array specifying the directories where
+# the primary segment data will be stored. Each directory corresponds to a
+# primary segment. In this case, two primary segments will be created in the
+# same directory.
+declare -a DATA_DIRECTORY=(/data1/primary /data1/primary)
+
+# Base port for mirror segments - The starting port number for the mirror
+# segments. Each mirror segment will use a unique port number starting from
+# this base.
+MIRROR_PORT_BASE=7000
+
+# Mirror segment data directories - An array specifying the directories where
+# the mirror segment data will be stored. Each directory corresponds to a
+# mirror segment. In this case, two mirror segments will be created in the
+# same directory.
+declare -a MIRROR_DATA_DIRECTORY=(/data1/mirror /data1/mirror)
+
+# Trusted shell - The shell program used for remote execution. Cloudberry uses
+# SSH to run commands on other machines in the cluster. 'ssh' is the default.
+TRUSTED_SHELL=ssh
+
+# Database encoding - The character set encoding to be used by the database.
+# 'UNICODE' is a common choice, especially for internationalization.
+ENCODING=UNICODE
+
+# Default database name - The name of the default database to be created during
+# initialization. This is also the default database that the gpadmin user will
+# connect to.
+DATABASE_NAME=gpadmin
+
+# Machine list file - A file containing the list of hostnames where the primary
+# segments will be created. Each line in the file represents a different machine.
+# This file is critical for setting up the cluster across multiple nodes.
+MACHINE_LIST_FILE=/home/gpadmin/hostfile_gpinitsystem
+
+# --------------------------------------------------------------------
+# End of gpinitsystem Configuration File
+# --------------------------------------------------------------------

--- a/images/docker/cbdb/test/rocky8/configs/init_system.sh
+++ b/images/docker/cbdb/test/rocky8/configs/init_system.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+# Container Initialization Script
+# --------------------------------------------------------------------
+# This script sets up the environment inside the Docker container for
+# the Apache Cloudberry Build Environment. It performs the following
+# tasks:
+#
+# 1. Verifies that the container is running with the expected hostname.
+# 2. Starts the SSH daemon to allow SSH access to the container.
+# 3. Configures passwordless SSH access for the 'gpadmin' user.
+# 4. Sets up the necessary directories and configuration files for
+#    Apache Cloudberry.
+# 5. Displays a welcome banner and system information.
+# 6. Starts an interactive bash shell.
+#
+# This script is intended to be used as an entrypoint or initialization
+# script for the Docker container.
+# --------------------------------------------------------------------
+
+# --------------------------------------------------------------------
+# Check if the hostname is 'cdw'
+# --------------------------------------------------------------------
+# The script checks if the container's hostname is set to 'cdw'. This is
+# a requirement for this environment, and if the hostname does not match,
+# the script will exit with an error message. This ensures consistency
+# across different environments.
+# --------------------------------------------------------------------
+if [ "$(hostname)" != "cdw" ]; then
+    echo "Error: This container must be run with the hostname 'cdw'."
+    echo "Use the following command: docker run -h cdw ..."
+    exit 1
+fi
+
+# --------------------------------------------------------------------
+# Start SSH daemon and setup for SSH access
+# --------------------------------------------------------------------
+# The SSH daemon is started to allow remote access to the container via
+# SSH. This is useful for development and debugging purposes. If the SSH
+# daemon fails to start, the script exits with an error.
+# --------------------------------------------------------------------
+if ! sudo /usr/sbin/sshd; then
+    echo "Failed to start SSH daemon" >&2
+    exit 1
+fi
+
+# --------------------------------------------------------------------
+# Remove /run/nologin to allow logins
+# --------------------------------------------------------------------
+# The /run/nologin file, if present, prevents users from logging into
+# the system. This file is removed to ensure that users can log in via SSH.
+# --------------------------------------------------------------------
+sudo rm -rf /run/nologin
+
+# --------------------------------------------------------------------
+# Configure passwordless SSH access for 'gpadmin' user
+# --------------------------------------------------------------------
+# The script sets up SSH key-based authentication for the 'gpadmin' user,
+# allowing passwordless SSH access. It generates a new SSH key pair if one
+# does not already exist, and configures the necessary permissions.
+# --------------------------------------------------------------------
+mkdir -p /home/gpadmin/.ssh
+chmod 700 /home/gpadmin/.ssh
+
+if [ ! -f /home/gpadmin/.ssh/id_rsa ]; then
+    ssh-keygen -t rsa -b 4096 -C gpadmin -f /home/gpadmin/.ssh/id_rsa -P "" > /dev/null 2>&1
+fi
+
+cat /home/gpadmin/.ssh/id_rsa.pub >> /home/gpadmin/.ssh/authorized_keys
+chmod 600 /home/gpadmin/.ssh/authorized_keys
+
+# Add the container's hostname to the known_hosts file to avoid SSH warnings
+ssh-keyscan -t rsa cdw > /home/gpadmin/.ssh/known_hosts 2>/dev/null
+
+# --------------------------------------------------------------------
+# Cloudberry Data Directories Setup
+# --------------------------------------------------------------------
+# The script sets up the necessary directories for Apache Cloudberry,
+# including directories for the coordinator, standby coordinator, primary
+# segments, and mirror segments. It also sets up the configuration files
+# required for initializing the database.
+# --------------------------------------------------------------------
+sudo rm -rf /data1/*
+sudo mkdir -p /data1/coordinator /data1/standby_coordinator /data1/primary /data1/mirror
+sudo chown -R gpadmin.gpadmin /data1
+
+# Copy the gpinitsystem configuration file to the home directory
+cp /tmp/gpinitsystem.conf /home/gpadmin
+
+# Set up the hostfile for cluster initialization
+echo $(hostname) > /home/gpadmin/hostfile_gpinitsystem
+
+# Change to the home directory of the current user
+cd $HOME
+
+# --------------------------------------------------------------------
+# Display a Welcome Banner
+# --------------------------------------------------------------------
+# The following ASCII art and welcome message are displayed when the
+# container starts. This banner provides a visual indication that the
+# container is running in the Apache Cloudberry Build Environment.
+# --------------------------------------------------------------------
+cat <<-'EOF'
+
+======================================================================
+
+                          ++++++++++       ++++++
+                        ++++++++++++++   +++++++
+                       ++++        +++++ ++++
+                      ++++          +++++++++
+                   =+====         =============+
+                 ========       =====+      =====
+                ====  ====     ====           ====
+               ====    ===     ===             ====
+               ====            === ===         ====
+               ====            ===  ==--       ===
+                =====          ===== --       ====
+                 =====================     ======
+                   ============================
+                                     =-----=
+     ____  _                    _  _
+    / ___|| |  ___   _   _   __| || |__    ___  _ __  _ __  _   _
+   | |    | | / _ \ | | | | / _` || '_ \  / _ \| '__|| '__|| | | |
+   | |___ | || (_) || |_| || (_| || |_) ||  __/| |   | |   | |_| |
+    \____||_| \____  \__,_| \__,_||_.__/  \___||_|   |_|    \__, |
+                                                            |___/
+----------------------------------------------------------------------
+
+EOF
+
+# --------------------------------------------------------------------
+# Display System Information
+# --------------------------------------------------------------------
+# The script sources the /etc/os-release file to retrieve the operating
+# system name and version. It then displays the following information:
+# - OS name and version
+# - Current user
+# - Container hostname
+# - IP address
+# - CPU model name and number of cores
+# - Total memory available
+# - Cloudberry version (if installed)
+# This information is useful for users to understand the environment they
+# are working in.
+# --------------------------------------------------------------------
+source /etc/os-release
+
+# Check if Apache Cloudberry is installed and display its version
+if rpm -q apache-cloudberry-db-incubating > /dev/null 2>&1; then
+    CBDB_VERSION=$(/usr/local/cbdb/bin/postgres --gp-version)
+else
+    CBDB_VERSION="Not installed"
+fi
+
+cat <<-EOF
+Welcome to the Apache Cloudberry Test Environment!
+
+Cloudberry version .. : $CBDB_VERSION
+Container OS ........ : $NAME $VERSION
+User ................ : $(whoami)
+Container hostname .. : $(hostname)
+IP Address .......... : $(hostname -I | awk '{print $1}')
+CPU Info ............ : $(lscpu | grep 'Model name:' | awk '{print substr($0, index($0,$3))}')
+CPU(s) .............. : $(nproc)
+Memory .............. : $(free -h | grep Mem: | awk '{print $2}') total
+======================================================================
+
+EOF
+
+# --------------------------------------------------------------------
+# Start an interactive bash shell
+# --------------------------------------------------------------------
+# Finally, the script starts an interactive bash shell to keep the
+# container running and allow the user to interact with the environment.
+# --------------------------------------------------------------------
+/bin/bash

--- a/images/docker/cbdb/test/rocky9/Dockerfile
+++ b/images/docker/cbdb/test/rocky9/Dockerfile
@@ -1,0 +1,133 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Apache Cloudberry (incubating) is an effort undergoing incubation at
+# the Apache Software Foundation (ASF), sponsored by the Apache
+# Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a
+# further review indicates that the infrastructure, communications,
+# and decision making process have stabilized in a manner consistent
+# with other successful ASF projects.
+#
+# While incubation status is not necessarily a reflection of the
+# completeness or stability of the code, it does indicate that the
+# project has yet to be fully endorsed by the ASF.
+#
+# --------------------------------------------------------------------
+# Dockerfile for Cloudberry Database Base Environment
+# --------------------------------------------------------------------
+# This Dockerfile sets up a Rocky Linux 9-based container to serve as
+# a base environment for evaluating the Cloudberry Database. It installs
+# necessary system utilities, configures the environment for SSH access,
+# and sets up a 'gpadmin' user with sudo privileges. The Cloudberry
+# Database RPM can be installed into this container for testing and
+# functional verification.
+#
+# Key Features:
+# - Locale setup for en_US.UTF-8
+# - SSH daemon setup for remote access
+# - Essential system utilities installation
+# - Separate user creation and configuration steps
+#
+# Security Considerations:
+# - This Dockerfile prioritizes ease of use for functional testing and
+#   evaluation. It includes configurations such as passwordless sudo access
+#   for the 'gpadmin' user and SSH access with password authentication.
+# - These configurations are suitable for testing and development but
+#   should NOT be used in a production environment due to potential security
+#   risks.
+#
+# Usage:
+#   docker build -t cloudberry-db-base-env .
+#   docker run -h cdw -it cloudberry-db-base-env
+# --------------------------------------------------------------------
+
+# Base image: Rocky Linux 9
+FROM rockylinux/rockylinux:9
+
+# Argument for configuring the timezone
+ARG TIMEZONE_VAR="America/Los_Angeles"
+
+# Environment variables for locale
+ENV LANG=en_US.UTF-8
+
+# --------------------------------------------------------------------
+# System Update and Installation
+# --------------------------------------------------------------------
+# Update the system and install essential system utilities required for
+# running and testing Cloudberry Database. Cleanup the DNF cache afterward
+# to reduce the image size.
+# --------------------------------------------------------------------
+RUN dnf install -y \
+        glibc-locale-source \
+        make \
+        openssh \
+        openssh-clients \
+        openssh-server \
+        procps-ng \
+        sudo \
+        which \
+        && \
+    dnf clean all  # Clean up DNF cache after package installations
+
+# --------------------------------------------------------------------
+# User Creation and Configuration
+# --------------------------------------------------------------------
+# - Create the 'gpadmin' user and group.
+# - Configure the 'gpadmin' user with passwordless sudo privileges.
+# - Add Cloudberry-specific entries to the gpadmin's .bashrc.
+# --------------------------------------------------------------------
+RUN /usr/sbin/groupadd gpadmin && \
+    /usr/sbin/useradd gpadmin -g gpadmin -G wheel && \
+    echo 'gpadmin ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/90-gpadmin && \
+    echo -e '\n# Add Cloudberry entries\nif [ -f /usr/local/cloudberry/greenplum_path.sh ]; then\n  source /usr/local/cloudberry/greenplum_path.sh\n  export COORDINATOR_DATA_DIRECTORY=/data1/coordinator/gpseg-1\nfi' >> /home/gpadmin/.bashrc
+
+# --------------------------------------------------------------------
+# Copy Configuration Files and Setup the Environment
+# --------------------------------------------------------------------
+# - Copy custom configuration files from the build context to /tmp/.
+# - Apply custom system limits and timezone.
+# - Set up SSH for password-based authentication.
+# - Generate locale and set the default locale to en_US.UTF-8.
+# --------------------------------------------------------------------
+COPY ./configs/* /tmp/
+
+RUN cp /tmp/90-cbdb-limits /etc/security/limits.d/90-cbdb-limits && \
+    sed -i.bak -r 's/^(session\s+required\s+pam_limits.so)/#\1/' /etc/pam.d/* && \
+    cat /usr/share/zoneinfo/${TIMEZONE_VAR} > /etc/localtime && \
+    chmod 777 /tmp/init_system.sh && \
+    setcap cap_net_raw+ep /usr/bin/ping && \
+    ssh-keygen -A && \
+    echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config && \
+    localedef -i en_US -f UTF-8 en_US.UTF-8 && \
+    echo "LANG=en_US.UTF-8" | tee /etc/locale.conf
+
+# --------------------------------------------------------------------
+# Set the Default User and Command
+# --------------------------------------------------------------------
+# The default user is set to 'gpadmin', and the container starts by
+# running the init_system.sh script. This container serves as a base
+# environment, and the Cloudberry Database RPM can be installed for
+# testing and functional verification.
+# --------------------------------------------------------------------
+USER gpadmin
+
+CMD ["bash","-c","/tmp/init_system.sh"]

--- a/images/docker/cbdb/test/rocky9/configs/90-cbdb-limits
+++ b/images/docker/cbdb/test/rocky9/configs/90-cbdb-limits
@@ -1,0 +1,32 @@
+# /etc/security/limits.d/90-db-limits
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+
+# Core dump file size limits for gpadmin
+gpadmin soft core unlimited
+gpadmin hard core unlimited
+
+# Open file limits for gpadmin
+gpadmin soft nofile 524288
+gpadmin hard nofile 524288
+
+# Process limits for gpadmin
+gpadmin soft nproc 131072
+gpadmin hard nproc 131072

--- a/images/docker/cbdb/test/rocky9/configs/gpinitsystem.conf
+++ b/images/docker/cbdb/test/rocky9/configs/gpinitsystem.conf
@@ -1,0 +1,87 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# ----------------------------------------------------------------------
+# gpinitsystem Configuration File for Cloudberry Database
+# ----------------------------------------------------------------------
+# This configuration file is used to initialize a Cloudberry Database
+# cluster. It defines the settings for the coordinator, primary segments,
+# and mirrors, as well as other important configuration options.
+# ----------------------------------------------------------------------
+
+# Segment prefix - This prefix is used for naming the segment directories.
+# For example, the primary segment directories will be named gpseg0, gpseg1, etc.
+SEG_PREFIX=gpseg
+
+# Coordinator port - The port number where the coordinator will listen.
+# This is the port used by clients to connect to the database.
+COORDINATOR_PORT=5432
+
+# Coordinator hostname - The hostname of the machine where the coordinator
+# will be running. The $(hostname) command will automatically insert the
+# hostname of the current machine.
+COORDINATOR_HOSTNAME=$(hostname)
+
+# Coordinator data directory - The directory where the coordinator's data
+# will be stored. This directory should have enough space to store metadata
+# and system catalogs.
+COORDINATOR_DIRECTORY=/data1/coordinator
+
+# Base port for primary segments - The starting port number for the primary
+# segments. Each primary segment will use a unique port number starting from
+# this base.
+PORT_BASE=6000
+
+# Primary segment data directories - An array specifying the directories where
+# the primary segment data will be stored. Each directory corresponds to a
+# primary segment. In this case, two primary segments will be created in the
+# same directory.
+declare -a DATA_DIRECTORY=(/data1/primary /data1/primary)
+
+# Base port for mirror segments - The starting port number for the mirror
+# segments. Each mirror segment will use a unique port number starting from
+# this base.
+MIRROR_PORT_BASE=7000
+
+# Mirror segment data directories - An array specifying the directories where
+# the mirror segment data will be stored. Each directory corresponds to a
+# mirror segment. In this case, two mirror segments will be created in the
+# same directory.
+declare -a MIRROR_DATA_DIRECTORY=(/data1/mirror /data1/mirror)
+
+# Trusted shell - The shell program used for remote execution. Cloudberry uses
+# SSH to run commands on other machines in the cluster. 'ssh' is the default.
+TRUSTED_SHELL=ssh
+
+# Database encoding - The character set encoding to be used by the database.
+# 'UNICODE' is a common choice, especially for internationalization.
+ENCODING=UNICODE
+
+# Default database name - The name of the default database to be created during
+# initialization. This is also the default database that the gpadmin user will
+# connect to.
+DATABASE_NAME=gpadmin
+
+# Machine list file - A file containing the list of hostnames where the primary
+# segments will be created. Each line in the file represents a different machine.
+# This file is critical for setting up the cluster across multiple nodes.
+MACHINE_LIST_FILE=/home/gpadmin/hostfile_gpinitsystem
+
+# ----------------------------------------------------------------------
+# End of gpinitsystem Configuration File
+# ----------------------------------------------------------------------

--- a/images/docker/cbdb/test/rocky9/configs/init_system.sh
+++ b/images/docker/cbdb/test/rocky9/configs/init_system.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+# Container Initialization Script
+# --------------------------------------------------------------------
+# This script sets up the environment inside the Docker container for
+# the Apache Cloudberry Build Environment. It performs the following
+# tasks:
+#
+# 1. Verifies that the container is running with the expected hostname.
+# 2. Starts the SSH daemon to allow SSH access to the container.
+# 3. Configures passwordless SSH access for the 'gpadmin' user.
+# 4. Sets up the necessary directories and configuration files for
+#    Apache Cloudberry.
+# 5. Displays a welcome banner and system information.
+# 6. Starts an interactive bash shell.
+#
+# This script is intended to be used as an entrypoint or initialization
+# script for the Docker container.
+# --------------------------------------------------------------------
+
+# --------------------------------------------------------------------
+# Check if the hostname is 'cdw'
+# --------------------------------------------------------------------
+# The script checks if the container's hostname is set to 'cdw'. This is
+# a requirement for this environment, and if the hostname does not match,
+# the script will exit with an error message. This ensures consistency
+# across different environments.
+# --------------------------------------------------------------------
+if [ "$(hostname)" != "cdw" ]; then
+    echo "Error: This container must be run with the hostname 'cdw'."
+    echo "Use the following command: docker run -h cdw ..."
+    exit 1
+fi
+
+# --------------------------------------------------------------------
+# Start SSH daemon and setup for SSH access
+# --------------------------------------------------------------------
+# The SSH daemon is started to allow remote access to the container via
+# SSH. This is useful for development and debugging purposes. If the SSH
+# daemon fails to start, the script exits with an error.
+# --------------------------------------------------------------------
+if ! sudo /usr/sbin/sshd; then
+    echo "Failed to start SSH daemon" >&2
+    exit 1
+fi
+
+# --------------------------------------------------------------------
+# Remove /run/nologin to allow logins
+# --------------------------------------------------------------------
+# The /run/nologin file, if present, prevents users from logging into
+# the system. This file is removed to ensure that users can log in via SSH.
+# --------------------------------------------------------------------
+sudo rm -rf /run/nologin
+
+# --------------------------------------------------------------------
+# Configure passwordless SSH access for 'gpadmin' user
+# --------------------------------------------------------------------
+# The script sets up SSH key-based authentication for the 'gpadmin' user,
+# allowing passwordless SSH access. It generates a new SSH key pair if one
+# does not already exist, and configures the necessary permissions.
+# --------------------------------------------------------------------
+mkdir -p /home/gpadmin/.ssh
+chmod 700 /home/gpadmin/.ssh
+
+if [ ! -f /home/gpadmin/.ssh/id_rsa ]; then
+    ssh-keygen -t rsa -b 4096 -C gpadmin -f /home/gpadmin/.ssh/id_rsa -P "" > /dev/null 2>&1
+fi
+
+cat /home/gpadmin/.ssh/id_rsa.pub >> /home/gpadmin/.ssh/authorized_keys
+chmod 600 /home/gpadmin/.ssh/authorized_keys
+
+# Add the container's hostname to the known_hosts file to avoid SSH warnings
+ssh-keyscan -t rsa cdw > /home/gpadmin/.ssh/known_hosts 2>/dev/null
+
+# --------------------------------------------------------------------
+# Cloudberry Data Directories Setup
+# --------------------------------------------------------------------
+# The script sets up the necessary directories for Apache Cloudberry,
+# including directories for the coordinator, standby coordinator, primary
+# segments, and mirror segments. It also sets up the configuration files
+# required for initializing the database.
+# --------------------------------------------------------------------
+sudo rm -rf /data1/*
+sudo mkdir -p /data1/coordinator /data1/standby_coordinator /data1/primary /data1/mirror
+sudo chown -R gpadmin.gpadmin /data1
+
+# Copy the gpinitsystem configuration file to the home directory
+cp /tmp/gpinitsystem.conf /home/gpadmin
+
+# Set up the hostfile for cluster initialization
+echo $(hostname) > /home/gpadmin/hostfile_gpinitsystem
+
+# Change to the home directory of the current user
+cd $HOME
+
+# --------------------------------------------------------------------
+# Display a Welcome Banner
+# --------------------------------------------------------------------
+# The following ASCII art and welcome message are displayed when the
+# container starts. This banner provides a visual indication that the
+# container is running in the Apache Cloudberry Build Environment.
+# --------------------------------------------------------------------
+cat <<-'EOF'
+
+======================================================================
+
+                          ++++++++++       ++++++
+                        ++++++++++++++   +++++++
+                       ++++        +++++ ++++
+                      ++++          +++++++++
+                   =+====         =============+
+                 ========       =====+      =====
+                ====  ====     ====           ====
+               ====    ===     ===             ====
+               ====            === ===         ====
+               ====            ===  ==--       ===
+                =====          ===== --       ====
+                 =====================     ======
+                   ============================
+                                     =-----=
+     ____  _                    _  _
+    / ___|| |  ___   _   _   __| || |__    ___  _ __  _ __  _   _
+   | |    | | / _ \ | | | | / _` || '_ \  / _ \| '__|| '__|| | | |
+   | |___ | || (_) || |_| || (_| || |_) ||  __/| |   | |   | |_| |
+    \____||_| \____  \__,_| \__,_||_.__/  \___||_|   |_|    \__, |
+                                                            |___/
+----------------------------------------------------------------------
+
+EOF
+
+# --------------------------------------------------------------------
+# Display System Information
+# --------------------------------------------------------------------
+# The script sources the /etc/os-release file to retrieve the operating
+# system name and version. It then displays the following information:
+# - OS name and version
+# - Current user
+# - Container hostname
+# - IP address
+# - CPU model name and number of cores
+# - Total memory available
+# - Cloudberry version (if installed)
+# This information is useful for users to understand the environment they
+# are working in.
+# --------------------------------------------------------------------
+source /etc/os-release
+
+# Check if Apache Cloudberry is installed and display its version
+if rpm -q apache-cloudberry-db-incubating > /dev/null 2>&1; then
+    CBDB_VERSION=$(/usr/local/cbdb/bin/postgres --gp-version)
+else
+    CBDB_VERSION="Not installed"
+fi
+
+cat <<-EOF
+Welcome to the Apache Cloudberry Test Environment!
+
+Cloudberry version .. : $CBDB_VERSION
+Container OS ........ : $NAME $VERSION
+User ................ : $(whoami)
+Container hostname .. : $(hostname)
+IP Address .......... : $(hostname -I | awk '{print $1}')
+CPU Info ............ : $(lscpu | grep 'Model name:' | awk '{print substr($0, index($0,$3))}')
+CPU(s) .............. : $(nproc)
+Memory .............. : $(free -h | grep Mem: | awk '{print $2}') total
+======================================================================
+
+EOF
+
+# --------------------------------------------------------------------
+# Start an interactive bash shell
+# --------------------------------------------------------------------
+# Finally, the script starts an interactive bash shell to keep the
+# container running and allow the user to interact with the environment.
+# --------------------------------------------------------------------
+/bin/bash


### PR DESCRIPTION
- Include Dockerfiles for Rocky Linux 8 and 9 based build and test environments
- Add test scripts, configuration files, and automation support for containerized builds
- Provide necessary scripts for testing and deploying across both supported environments
- Add GitHub workflow files for building and testing containersAdd initial Dockerfiles and configs for Cloudberry