### PR TITLE
build: add Apache Cloudberry build automation and test framework

### DIFF
--- a/build_automation/cloudberry/scripts/build-cloudberry.sh
+++ b/build_automation/cloudberry/scripts/build-cloudberry.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Script: build-cloudberry.sh
+# Description: Builds Apache Cloudberry from source code and installs
+# it.
+#             Performs the following steps:
+#             1. Builds main Apache Cloudberry database components
+#             2. Builds contrib modules
+#             3. Installs both main and contrib components
+#             Uses parallel compilation based on available CPU cores.
+#
+# Required Environment Variables:
+#   SRC_DIR - Root source directory containing Apache Cloudberry
+#   source code
+#
+# Optional Environment Variables:
+#   LOG_DIR - Directory for logs (defaults to ${SRC_DIR}/build-logs)
+#   NPROC   - Number of parallel jobs (defaults to all available cores)
+#
+# Usage:
+#   Export required variables:
+#     export SRC_DIR=/path/to/cloudberry/source
+#   Then run:
+#     ./build-cloudberry.sh
+#
+# Prerequisites:
+#   - configure-cloudberry.sh must be run first
+#   - Required build dependencies must be installed
+#   - /usr/local/cloudberry-db/lib must exist and be writable
+#
+# Exit Codes:
+#   0 - Build and installation completed successfully
+#   1 - Environment setup failed (missing SRC_DIR, LOG_DIR creation failed)
+#   2 - Main component build failed
+#   3 - Contrib build failed
+#   4 - Installation failed
+#
+# --------------------------------------------------------------------
+
+set -euo pipefail
+
+# Source common utilities
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}/cloudberry-utils.sh"
+
+# Define log directory and files
+export LOG_DIR="${SRC_DIR}/build-logs"
+BUILD_LOG="${LOG_DIR}/build.log"
+
+# Initialize environment
+init_environment "Cloudberry Build Script" "${BUILD_LOG}"
+
+# Set environment
+log_section "Environment Setup"
+export LD_LIBRARY_PATH=/usr/local/cloudberry-db/lib:LD_LIBRARY_PATH
+log_section_end "Environment Setup"
+
+# Build process
+log_section "Build Process"
+execute_cmd make -j$(nproc) --directory ${SRC_DIR} || exit 2
+execute_cmd make -j$(nproc) --directory ${SRC_DIR}/contrib || exit 3
+log_section_end "Build Process"
+
+# Installation
+log_section "Installation"
+execute_cmd make install --directory ${SRC_DIR} || exit 4
+execute_cmd make install --directory ${SRC_DIR}/contrib || exit 4
+log_section_end "Installation"
+
+# Log completion
+log_completion "Cloudberry Build Script" "${BUILD_LOG}"
+exit 0

--- a/build_automation/cloudberry/scripts/cloudberry-utils.sh
+++ b/build_automation/cloudberry/scripts/cloudberry-utils.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Library: cloudberry-utils.sh
+# Description: Common utility functions for Apache Cloudberry build
+# and test scripts
+#
+# Required Environment Variables:
+#   SRC_DIR - Root source directory
+#
+# Optional Environment Variables:
+#   LOG_DIR - Directory for logs (defaults to ${SRC_DIR}/build-logs)
+#
+# Functions:
+#   init_environment "Script Name" "Log File"
+#     - Initialize logging and verify environment
+#     - Parameters:
+#       * script_name: Name of the calling script
+#       * log_file: Path to log file
+#     - Returns: 0 on success, 1 on failure
+#
+#   execute_cmd command [args...]
+#     - Execute command with logging
+#     - Parameters: Command and its arguments
+#     - Returns: Command's exit code
+#
+#   run_psql_cmd "sql_command"
+#     - Execute PostgreSQL command with logging
+#     - Parameters: SQL command string
+#     - Returns: psql command's exit code
+#
+#   source_cloudberry_env
+#     - Source Cloudberry environment files
+#     - Returns: 0 on success
+#
+#   log_section "section_name"
+#     - Log section start
+#     - Parameters: Name of the section
+#
+#   log_section_end "section_name"
+#     - Log section end
+#     - Parameters: Name of the section
+#
+#   log_completion "script_name" "log_file"
+#     - Log script completion
+#     - Parameters:
+#       * script_name: Name of the calling script
+#       * log_file: Path to log file
+#
+# Usage:
+#   source ./cloudberry-utils.sh
+#
+# Example:
+#   source ./cloudberry-utils.sh
+#   init_environment "My Script" "${LOG_FILE}"
+#   execute_cmd make clean
+#   log_section "Build Process"
+#   execute_cmd make -j$(nproc)
+#   log_section_end "Build Process"
+#   log_completion "My Script" "${LOG_FILE}"
+#
+# --------------------------------------------------------------------
+
+# Initialize logging and environment
+init_environment() {
+    local script_name=$1
+    local log_file=$2
+
+    echo "=== Initializing environment for ${script_name} ==="
+    echo "${script_name} executed at $(date)" | tee -a "${log_file}"
+    echo "Whoami: $(whoami)" | tee -a "${log_file}"
+    echo "Hostname: $(hostname)" | tee -a "${log_file}"
+    echo "Working directory: $(pwd)" | tee -a "${log_file}"
+    echo "Source directory: ${SRC_DIR}" | tee -a "${log_file}"
+    echo "Log directory: ${LOG_DIR}" | tee -a "${log_file}"
+
+    if [ -z "${SRC_DIR:-}" ]; then
+        echo "Error: SRC_DIR environment variable is not set" | tee -a "${log_file}"
+        exit 1
+    fi
+
+    mkdir -p "${LOG_DIR}"
+}
+
+# Function to echo and execute command with logging
+execute_cmd() {
+    local cmd_str="$*"
+    local timestamp=$(date "+%Y.%m.%d-%H.%M.%S")
+    echo "Executing at ${timestamp}: $cmd_str" | tee -a "${LOG_DIR}/commands.log"
+    "$@" 2>&1 | tee -a "${LOG_DIR}/commands.log"
+    return ${PIPESTATUS[0]}
+}
+
+# Function to run psql commands with logging
+run_psql_cmd() {
+    local cmd=$1
+    local timestamp=$(date "+%Y.%m.%d-%H.%M.%S")
+    echo "Executing psql at ${timestamp}: $cmd" | tee -a "${LOG_DIR}/psql-commands.log"
+    psql -P pager=off template1 -c "$cmd" 2>&1 | tee -a "${LOG_DIR}/psql-commands.log"
+    return ${PIPESTATUS[0]}
+}
+
+# Function to source Cloudberry environment
+source_cloudberry_env() {
+    echo "=== Sourcing Cloudberry environment ===" | tee -a "${LOG_DIR}/environment.log"
+    source /usr/local/cloudberry-db/greenplum_path.sh
+    source ${SRC_DIR}/../cloudberry/gpAux/gpdemo/gpdemo-env.sh
+}
+
+# Function to log section start
+log_section() {
+    local section_name=$1
+    local timestamp=$(date "+%Y.%m.%d-%H.%M.%S")
+    echo "=== ${section_name} started at ${timestamp} ===" | tee -a "${LOG_DIR}/sections.log"
+}
+
+# Function to log section end
+log_section_end() {
+    local section_name=$1
+    local timestamp=$(date "+%Y.%m.%d-%H.%M.%S")
+    echo "=== ${section_name} completed at ${timestamp} ===" | tee -a "${LOG_DIR}/sections.log"
+}
+
+# Function to log script completion
+log_completion() {
+    local script_name=$1
+    local log_file=$2
+    local timestamp=$(date "+%Y.%m.%d-%H.%M.%S")
+    echo "${script_name} execution completed successfully at ${timestamp}" | tee -a "${log_file}"
+}

--- a/build_automation/cloudberry/scripts/configure-cloudberry.sh
+++ b/build_automation/cloudberry/scripts/configure-cloudberry.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Script: configure-cloudberry.sh
+# Description: Configures Apache Cloudberry build environment and runs
+#             ./configure with optimized settings. Performs the
+#             following:
+#             1. Prepares /usr/local/cloudberry-db directory
+#             2. Sets up library dependencies
+#             3. Configures build with required features enabled
+#
+# Configuration Features:
+#   - Cloud Storage Integration (gpcloud)
+#   - IC Proxy Support
+#   - MapReduce Processing
+#   - Oracle Compatibility (orafce)
+#   - ORCA Query Optimizer
+#   - PXF External Table Access
+#   - Test Automation Support (tap-tests)
+#
+# System Integration:
+#   - GSSAPI Authentication
+#   - LDAP Authentication
+#   - XML Processing
+#   - LZ4 Compression
+#   - OpenSSL Support
+#   - PAM Authentication
+#   - Perl Support
+#   - Python Support
+#
+# Required Environment Variables:
+#   SRC_DIR - Root source directory
+#
+# Optional Environment Variables:
+#   LOG_DIR - Directory for logs (defaults to ${SRC_DIR}/build-logs)
+#
+# Prerequisites:
+#   - System dependencies must be installed:
+#     * xerces-c development files
+#     * OpenSSL development files
+#     * Python development files
+#     * Perl development files
+#     * LDAP development files
+#   - /usr/local must be writable
+#   - User must have sudo privileges
+#
+# Usage:
+#   Export required variables:
+#     export SRC_DIR=/path/to/cloudberry/source
+#   Then run:
+#     ./configure-cloudberry.sh
+#
+# Exit Codes:
+#   0 - Configuration completed successfully
+#   1 - Environment setup failed
+#   2 - Directory preparation failed
+#   3 - Library setup failed
+#   4 - Configure command failed
+#
+# --------------------------------------------------------------------
+
+set -euo pipefail
+
+# Source common utilities
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}/cloudberry-utils.sh"
+
+# Define log directory and files
+export LOG_DIR="${SRC_DIR}/build-logs"
+CONFIGURE_LOG="${LOG_DIR}/configure.log"
+
+# Initialize environment
+init_environment "Cloudberry Configure Script" "${CONFIGURE_LOG}"
+
+# Initial setup
+log_section "Initial Setup"
+execute_cmd sudo rm -rf /usr/local/cloudberry-db || exit 2
+execute_cmd sudo chmod a+w /usr/local || exit 2
+execute_cmd mkdir -p /usr/local/cloudberry-db/lib || exit 2
+execute_cmd sudo cp /usr/local/xerces-c/lib/libxerces-c.so \
+        /usr/local/xerces-c/lib/libxerces-c-3.3.so \
+        /usr/local/cloudberry-db/lib || exit 3
+execute_cmd sudo chown -R gpadmin:gpadmin /usr/local/cloudberry-db || exit 2
+log_section_end "Initial Setup"
+
+# Set environment
+log_section "Environment Setup"
+export LD_LIBRARY_PATH=/usr/local/cloudberry-db/lib:LD_LIBRARY_PATH
+log_section_end "Environment Setup"
+
+# Configure build
+log_section "Configure"
+execute_cmd ./configure --prefix=/usr/local/cloudberry-db \
+            --disable-external-fts \
+            --enable-gpcloud \
+            --enable-ic-proxy \
+            --enable-mapreduce \
+            --enable-orafce \
+            --enable-orca \
+            --enable-pxf \
+            --enable-tap-tests \
+            --with-gssapi \
+            --with-ldap \
+            --with-libxml \
+            --with-lz4 \
+            --with-openssl \
+            --with-pam \
+            --with-perl \
+            --with-pgport=5432 \
+            --with-python \
+            --with-pythonsrc-ext \
+            --with-ssl=openssl \
+            --with-openssl \
+            --with-uuid=e2fs \
+            --with-includes=/usr/local/xerces-c/include \
+            --with-libraries=/usr/local/cloudberry-db/lib || exit 4
+log_section_end "Configure"
+
+# Capture version information
+log_section "Version Information"
+execute_cmd ag "GP_VERSION | GP_VERSION_NUM | PG_VERSION | PG_VERSION_NUM | PG_VERSION_STR" src/include/pg_config.h
+log_section_end "Version Information"
+
+# Log completion
+log_completion "Cloudberry Configure Script" "${CONFIGURE_LOG}"
+exit 0

--- a/build_automation/cloudberry/scripts/create-cloudberry-demo-cluster.sh
+++ b/build_automation/cloudberry/scripts/create-cloudberry-demo-cluster.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Script: create-cloudberry-demo-cluster.sh
+# Description: Creates and configures a demo Apache Cloudbery cluster.
+#             Performs the following steps:
+#             1. Sets up required environment variables
+#             2. Verifies SSH connectivity
+#             3. Creates demo cluster using make
+#             4. Initializes and starts the cluster
+#             5. Performs comprehensive verification checks
+#
+# Required Environment Variables:
+#   SRC_DIR - Root source directory
+#
+# Optional Environment Variables:
+#   LOG_DIR - Directory for logs (defaults to ${SRC_DIR}/build-logs)
+#
+# Prerequisites:
+#   - Apache Cloudberry must be installed (/usr/local/cloudberry-db)
+#   - SSH must be configured for passwordless access to localhost
+#   - User must have permissions to create cluster directories
+#   - PostgreSQL client tools (psql) must be available
+#
+# Usage:
+#   Export required variables:
+#     export SRC_DIR=/path/to/cloudberry/source
+#   Then run:
+#     ./create-cloudberry-demo-cluster.sh
+#
+# Verification Checks:
+#   - Apache Cloudberry version
+#   - Segment configuration
+#   - Available extensions
+#   - Active sessions
+#   - Configuration history
+#   - Replication status
+#
+# Exit Codes:
+#   0 - Cluster created and verified successfully
+#   1 - Environment setup failed
+#   2 - SSH verification failed
+#   3 - Cluster creation failed
+#   4 - Cluster startup failed
+#   5 - Verification checks failed
+#
+# --------------------------------------------------------------------
+
+set -euo pipefail
+
+# Source common utilities
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}/cloudberry-utils.sh"
+
+# Define log directory
+export LOG_DIR="${SRC_DIR}/build-logs"
+CLUSTER_LOG="${LOG_DIR}/cluster.log"
+
+# Initialize environment
+init_environment "Cloudberry Demo Cluster Script" "${CLUSTER_LOG}"
+
+# Setup environment
+log_section "Environment Setup"
+source /usr/local/cloudberry-db/greenplum_path.sh || exit 1
+log_section_end "Environment Setup"
+
+# Verify SSH access
+log_section "SSH Verification"
+execute_cmd ssh $(hostname) 'whoami; hostname' || exit 2
+log_section_end "SSH Verification"
+
+# Create demo cluster
+log_section "Demo Cluster Creation"
+execute_cmd make create-demo-cluster --directory ${SRC_DIR}/../cloudberry || exit 3
+log_section_end "Demo Cluster Creation"
+
+# Source demo environment
+log_section "Source Environment"
+source ${SRC_DIR}/../cloudberry/gpAux/gpdemo/gpdemo-env.sh || exit 1
+log_section_end "Source Environment"
+
+# Manage cluster state
+log_section "Cluster Management"
+execute_cmd gpstop -a || exit 4
+execute_cmd gpstart -a || exit 4
+execute_cmd gpstate || exit 4
+log_section_end "Cluster Management"
+
+# Verify installation
+log_section "Installation Verification"
+verification_failed=false
+run_psql_cmd "SELECT version()" || verification_failed=true
+run_psql_cmd "SELECT * from gp_segment_configuration" || verification_failed=true
+run_psql_cmd "SELECT * FROM pg_available_extensions" || verification_failed=true
+run_psql_cmd "SELECT * from pg_stat_activity" || verification_failed=true
+run_psql_cmd "SELECT * FROM gp_configuration_history" || verification_failed=true
+run_psql_cmd "SELECT * FROM gp_stat_replication" || verification_failed=true
+
+if [ "$verification_failed" = true ]; then
+    echo "One or more verification checks failed" | tee -a "${CLUSTER_LOG}"
+    exit 5
+fi
+log_section_end "Installation Verification"
+
+# Log completion
+log_completion "Cloudberry Demo Cluster Script" "${CLUSTER_LOG}"
+exit 0

--- a/build_automation/cloudberry/scripts/destroy-cloudberry-demo-cluster.sh
+++ b/build_automation/cloudberry/scripts/destroy-cloudberry-demo-cluster.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Script: destroy-cloudberry-demo-cluster.sh
+# Description: Destroys and cleans up a demo Apache Cloudberry
+# cluster.
+#             Performs the following steps:
+#             1. Sources required environment variables
+#             2. Stops any running cluster processes
+#             3. Removes cluster data directories and configuration
+#             4. Cleans up any remaining cluster resources
+#
+# Required Environment Variables:
+#   SRC_DIR - Root source directory
+#
+# Optional Environment Variables:
+#   LOG_DIR - Directory for logs (defaults to ${SRC_DIR}/build-logs)
+#
+# Prerequisites:
+#   - Apache Cloudberry environment must be available
+#   - User must have permissions to remove cluster directories
+#   - No active connections to the cluster
+#
+# Usage:
+#   Export required variables:
+#     export SRC_DIR=/path/to/cloudberry/source
+#   Then run:
+#     ./destroy-cloudberry-demo-cluster.sh
+#
+# Exit Codes:
+#   0 - Cluster destroyed successfully
+#   1 - Environment setup/sourcing failed
+#   2 - Cluster destruction failed
+#
+# Related Scripts:
+#   - create-cloudberry-demo-cluster.sh: Creates a new demo cluster
+#
+# Notes:
+#   - This script will forcefully terminate all cluster processes
+#   - All cluster data will be permanently deleted
+#   - Make sure to backup any important data before running
+#
+# --------------------------------------------------------------------
+
+set -euo pipefail
+
+# Source common utilities
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}/cloudberry-utils.sh"
+
+# Define log directory
+export LOG_DIR="${SRC_DIR}/build-logs"
+CLUSTER_LOG="${LOG_DIR}/destroy-cluster.log"
+
+# Initialize environment
+init_environment "Destroy Cloudberry Demo Cluster Script" "${CLUSTER_LOG}"
+
+# Source Cloudberry environment
+log_section "Environment Setup"
+source_cloudberry_env || {
+    echo "Failed to source Cloudberry environment" | tee -a "${CLUSTER_LOG}"
+    exit 1
+}
+log_section_end "Environment Setup"
+
+# Destroy demo cluster
+log_section "Destroy Demo Cluster"
+execute_cmd make destroy-demo-cluster --directory ${SRC_DIR}/../cloudberry || {
+    echo "Failed to destroy demo cluster" | tee -a "${CLUSTER_LOG}"
+    exit 2
+}
+log_section_end "Destroy Demo Cluster"
+
+# Verify cleanup
+log_section "Cleanup Verification"
+if [ -d "${SRC_DIR}/../cloudberry/gpAux/gpdemo/data" ]; then
+    echo "Warning: Data directory still exists after cleanup" | tee -a "${CLUSTER_LOG}"
+fi
+log_section_end "Cleanup Verification"
+
+# Log completion
+log_completion "Destroy Cloudberry Demo Cluster Script" "${CLUSTER_LOG}"
+exit 0

--- a/build_automation/cloudberry/scripts/parse-results.pl
+++ b/build_automation/cloudberry/scripts/parse-results.pl
@@ -1,0 +1,175 @@
+#!/usr/bin/env perl
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Script: parse_results.pl
+# Description: Processes Cloudberry test output to extract statistics
+# and results.
+#             Analyzes test log files to determine:
+#             1. Overall test status (pass/fail)
+#             2. Total number of tests run
+#             3. Number of passed and failed tests
+#             4. Names of failed tests
+#             Results are written to a file for shell script processing.
+#
+# Arguments:
+#   log-file    Path to test log file (required)
+#
+# Input File Format:
+#   Expects test log files containing either:
+#   - "All X tests passed."
+#   - "Y of X tests failed."
+#   And failed test entries in format:
+#   - "test_name ... FAILED"
+#
+# Output File (test_results.txt):
+#   Environment variable format:
+#   STATUS=passed|failed
+#   TOTAL_TESTS=<number>
+#   FAILED_TESTS=<number>
+#   PASSED_TESTS=<number>
+#   FAILED_TEST_NAMES=<comma-separated-list>
+#
+# Prerequisites:
+#   - Read access to input log file
+#   - Write access to current directory
+#   - Perl 5.x or higher
+#
+# Exit Codes:
+#   0 - All tests passed
+#   1 - Some tests failed (expected failure)
+#   2 - Parse error or cannot access files
+#
+# Example Usage:
+#   ./parse_results.pl test_output.log
+#
+# Error Handling:
+#   - Validates input file existence and readability
+#   - Verifies failed test count matches found failures
+#   - Reports parsing errors with detailed messages
+#
+# --------------------------------------------------------------------
+
+use strict;
+use warnings;
+
+# Exit codes
+use constant {
+    SUCCESS => 0,
+    TEST_FAILURE => 1,
+    PARSE_ERROR => 2
+};
+
+# Get log file path from command line argument
+my $file = $ARGV[0] or die "Usage: $0 LOG_FILE\n";
+print "Parsing test results from: $file\n";
+
+# Check if file exists and is readable
+unless (-e $file) {
+    print "Error: File does not exist: $file\n";
+    exit PARSE_ERROR;
+}
+unless (-r $file) {
+    print "Error: File is not readable: $file\n";
+    exit PARSE_ERROR;
+}
+
+# Open and parse the log file
+open(my $fh, '<', $file) or do {
+    print "Cannot open log file: $! (looking in $file)\n";
+    exit PARSE_ERROR;
+};
+
+my ($status, $total_tests, $failed_tests, $passed_tests);
+my @failed_test_list = ();
+
+while (<$fh>) {
+    # Match the summary lines
+    if (/All (\d+) tests passed\./) {
+        $status = 'passed';
+        $total_tests = $1;
+        $failed_tests = 0;
+        $passed_tests = $1;
+    }
+    elsif (/(\d+) of (\d+) tests failed\./) {
+        $status = 'failed';
+        $failed_tests = $1;
+        $total_tests = $2;
+        $passed_tests = $2 - $1;
+    }
+
+    # Capture failed tests
+    if (/^(?:\s+|test\s+)(\S+)\s+\.\.\.\s+FAILED\s+/) {
+        push @failed_test_list, $1;
+    }
+}
+close($fh);
+
+unless (defined $status) {
+    print "Error: Could not find test summary in $file\n";
+    exit PARSE_ERROR;
+}
+
+# Validate failed test count matches found test names
+if ($status eq 'failed' && scalar(@failed_test_list) != $failed_tests) {
+    print "Error: Found $failed_tests failed tests in summary but found " . scalar(@failed_test_list) . " failed test names\n";
+    print "Failed test names found:\n";
+    foreach my $test (@failed_test_list) {
+        print "  - $test\n";
+    }
+    exit PARSE_ERROR;
+}
+
+# Write results to file
+open(my $out, '>', 'test_results.txt') or do {
+    print "Cannot write results: $!\n";
+    exit PARSE_ERROR;
+};
+
+print $out "STATUS=$status\n";
+print $out "TOTAL_TESTS=$total_tests\n";
+print $out "FAILED_TESTS=$failed_tests\n";
+print $out "PASSED_TESTS=$passed_tests\n";
+if (@failed_test_list) {
+    print $out "FAILED_TEST_NAMES=" . join(",", @failed_test_list) . "\n";
+}
+close($out);
+
+# Print to stdout for logging
+print "Test Results:\n";
+print "Status: $status\n";
+print "Total Tests: $total_tests\n";
+print "Failed Tests: $failed_tests\n";
+print "Passed Tests: $passed_tests\n";
+if (@failed_test_list) {
+    print "Failed Test Names:\n";
+    foreach my $test (@failed_test_list) {
+        print "  - $test\n";
+    }
+}
+
+# Exit with appropriate code
+if ($status eq 'passed') {
+    exit SUCCESS;
+} elsif ($status eq 'failed') {
+    exit TEST_FAILURE;
+} else {
+    exit PARSE_ERROR;
+}

--- a/build_automation/cloudberry/scripts/parse-test-results.sh
+++ b/build_automation/cloudberry/scripts/parse-test-results.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Script: parse-test-results.sh
+# Description: Parses Apache Cloudberry test results and processes the
+# output.
+#             Provides GitHub Actions integration and environment
+#             variable export functionality. This script is a wrapper
+#             around parse_results.pl, adding the following features:
+#             1. Default log file path handling
+#             2. GitHub Actions output integration
+#             3. Environment variable management
+#             4. Result file cleanup
+#
+# Required Environment Variables:
+#   None
+#
+# Optional Environment Variables:
+#   GITHUB_OUTPUT - GitHub Actions output file path
+#   MAKE_NAME    - Used in default log path construction
+#
+# Arguments:
+#   [log-file] - Path to test log file
+#                (defaults to build-logs/details/make-${MAKE_NAME}.log)
+#
+# Prerequisites:
+#   - parse_results.pl must be in the same directory
+#   - Perl must be installed and in PATH
+#   - Write access to current directory (for temporary files)
+#   - Read access to test log file
+#
+# Output Variables (in GitHub Actions):
+#   status           - Test status (passed/failed)
+#   total_tests      - Total number of tests
+#   failed_tests     - Number of failed tests
+#   passed_tests     - Number of passed tests
+#   failed_test_names - Names of failed tests (comma-separated)
+#
+# Usage Examples:
+#   # Parse default log file:
+#   ./parse-test-results.sh
+#
+#   # Parse specific log file:
+#   ./parse-test-results.sh path/to/test.log
+#
+#   # Use with GitHub Actions:
+#   export GITHUB_OUTPUT=/path/to/output
+#   ./parse-test-results.sh
+#
+# Exit Codes:
+#   0 - All tests passed successfully
+#   1 - Tests failed but results were properly parsed
+#   2 - Parse error, missing files, or unknown status
+#
+# Files Created/Modified:
+#   - Temporary: test_results.txt (automatically cleaned up)
+#   - If GITHUB_OUTPUT set: Appends results to specified file
+#
+# --------------------------------------------------------------------
+
+set -euo pipefail
+
+# Default log file path
+DEFAULT_LOG_PATH="build-logs/details/make-${MAKE_NAME}.log"
+LOG_FILE=${1:-$DEFAULT_LOG_PATH}
+
+# Get the directory where this script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Check if log file exists
+if [ ! -f "$LOG_FILE" ]; then
+    echo "Error: Test log file not found: $LOG_FILE"
+    exit 2
+fi
+
+# Run the perl script and capture its exit code
+perl "${SCRIPT_DIR}/parse-results.pl" "$LOG_FILE"
+perl_exit_code=$?
+
+# Check if results file exists and source it if it does
+if [ ! -f test_results.txt ]; then
+    echo "Error: No results file generated"
+    exit 2
+fi
+
+source test_results.txt
+
+echo "Results loaded into environment variables:"
+echo "STATUS=$STATUS"
+echo "TOTAL_TESTS=$TOTAL_TESTS"
+echo "FAILED_TESTS=$FAILED_TESTS"
+echo "PASSED_TESTS=$PASSED_TESTS"
+if [ -n "${FAILED_TEST_NAMES:-}" ]; then
+    echo "FAILED_TEST_NAMES=$FAILED_TEST_NAMES"
+fi
+
+# If in GitHub Actions, set outputs
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+        echo "status=$STATUS"
+        echo "total_tests=$TOTAL_TESTS"
+        echo "failed_tests=$FAILED_TESTS"
+        echo "passed_tests=$PASSED_TESTS"
+        [ -n "${FAILED_TEST_NAMES:-}" ] && echo "failed_test_names=$FAILED_TEST_NAMES"
+    } >> "$GITHUB_OUTPUT"
+fi
+
+# Clean up
+rm -f test_results.txt
+
+# Return the perl script's exit code
+exit $perl_exit_code

--- a/build_automation/cloudberry/scripts/test-cloudberry.sh
+++ b/build_automation/cloudberry/scripts/test-cloudberry.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Script: test-cloudberry.sh
+# Description: Executes Apache Cloudberry test suite using specified
+#             make target.  Supports different test types through make
+#             target configuration.  Sources Cloudberry environment
+#             before running tests.
+#
+# Required Environment Variables:
+#   MAKE_TARGET    - Make target to execute (e.g., installcheck-world)
+#   MAKE_DIRECTORY - Directory where make command will be executed
+#   MAKE_NAME      - Name of the make operation (for logging)
+#
+# Optional Environment Variables:
+#   LOG_DIR - Directory for logs (defaults to build-logs)
+#   PGOPTIONS - PostgreSQL server options
+#
+# Usage:
+#   Export required variables:
+#     export MAKE_TARGET=installcheck-world
+#     export MAKE_DIRECTORY="/path/to/make/dir"
+#     export MAKE_NAME="Install Check"
+#   Then run:
+#     ./test-cloudberry.sh
+#
+# Exit Codes:
+#   0 - All tests passed successfully
+#   1 - Environment setup failed (missing required variables, environment sourcing failed)
+#   2 - Test execution failed (make command returned error)
+#
+# --------------------------------------------------------------------
+
+set -euo pipefail
+
+# Source common utilities
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}/cloudberry-utils.sh"
+
+# Define log directory and files
+export LOG_DIR="build-logs"
+TEST_LOG="${LOG_DIR}/test.log"
+
+# Initialize environment
+init_environment "Cloudberry Test Script" "${TEST_LOG}"
+
+# Source Cloudberry environment
+log_section "Environment Setup"
+source_cloudberry_env || exit 1
+log_section_end "Environment Setup"
+
+echo "MAKE_TARGET: ${MAKE_TARGET}"
+echo "MAKE_DIRECTORY: ${MAKE_DIRECTORY}"
+echo "PGOPTIONS: ${PGOPTIONS}"
+
+# Execute specified target
+log_section "Install Check"
+execute_cmd make ${MAKE_TARGET} ${MAKE_DIRECTORY} || exit 2
+log_section_end "Install Check"
+
+# Log completion
+log_completion "Cloudberry Test Script" "${TEST_LOG}"
+exit 0

--- a/build_automation/cloudberry/scripts/unittest-cloudberry.sh
+++ b/build_automation/cloudberry/scripts/unittest-cloudberry.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Script: unittest-cloudberry.sh
+# Description: Executes unit tests for Apache Cloudberry from source
+#             code.  Runs the 'unittest-check' make target and logs
+#             results.  Tests are executed against the compiled source
+#             without requiring a full installation.
+#
+# Required Environment Variables:
+#   SRC_DIR - Root source directory
+#
+# Optional Environment Variables:
+#   LOG_DIR - Directory for logs (defaults to ${SRC_DIR}/build-logs)
+#
+# Usage:
+#   ./unittest-cloudberry.sh
+#
+# Exit Codes:
+#   0 - All unit tests passed successfully
+#   1 - Environment setup failed (missing SRC_DIR, LOG_DIR creation failed)
+#   2 - Unit test execution failed
+#
+# --------------------------------------------------------------------
+
+set -euo pipefail
+
+# Source common utilities
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}/cloudberry-utils.sh"
+
+# Define log directory and files
+export LOG_DIR="${SRC_DIR}/build-logs"
+UNITTEST_LOG="${LOG_DIR}/unittest.log"
+
+# Initialize environment
+init_environment "Cloudberry Unittest Script" "${UNITTEST_LOG}"
+
+# Set environment
+log_section "Environment Setup"
+export LD_LIBRARY_PATH=/usr/local/cloudberry-db/lib:LD_LIBRARY_PATH
+log_section_end "Environment Setup"
+
+# Unittest process
+log_section "Unittest Process"
+execute_cmd make --directory ${SRC_DIR}/../cloudberry unittest-check || exit 2
+log_section_end "Unittest Process"
+
+# Log completion
+log_completion "Cloudberry Unittest Script" "${UNITTEST_LOG}"
+exit 0


### PR DESCRIPTION
Introduces a comprehensive build automation framework for Apache Cloudberry:

- Configure/build/test automation scripts with standardized logging
- Unit test and regression test execution framework
- Demo cluster creation and management utilities
- Test results parsing and reporting tools
- Shared utility functions for common operations

The framework provides:
- Consistent environment setup and teardown
- Standardized logging and error handling
- Clear exit codes and error reporting
- GitHub Actions integration support
- RPM package building capabilities

This commit establishes the foundation for Apache
Cloudberry (incubating)
CI/CD pipeline and release automation.