### PR TITLE
fix: remove -e from set options in parse-test-results.sh

### DIFF
--- a/build_automation/cloudberry/scripts/parse-test-results.sh
+++ b/build_automation/cloudberry/scripts/parse-test-results.sh
@@ -76,7 +76,7 @@
 #
 # --------------------------------------------------------------------
 
-set -euo pipefail
+set -uo pipefail
 
 # Default log file path
 DEFAULT_LOG_PATH="build-logs/details/make-${MAKE_NAME}.log"


### PR DESCRIPTION
Allow test_results.txt to be processed even when tests fail. Previously, -e was causing immediate script exit on test failures before GitHub outputs could be set, preventing proper status reporting and regression log uploads. Now the script properly handles both pass and fail cases.