### PR TITLE
Adding packages (gdb and file) used in core file analysis.

### DIFF
--- a/images/docker/cbdb/build/rocky8/Dockerfile
+++ b/images/docker/cbdb/build/rocky8/Dockerfile
@@ -84,9 +84,11 @@ RUN dnf makecache && \
         bison \
         bzip2-devel \
         diffutils \
+        file \
         flex \
         gcc \
         gcc-c++ \
+        gdb \
         glibc-langpack-en \
         glibc-locale-source \
         iproute \

--- a/images/docker/cbdb/build/rocky9/Dockerfile
+++ b/images/docker/cbdb/build/rocky9/Dockerfile
@@ -84,9 +84,11 @@ RUN dnf makecache && \
         bison \
         cmake3 \
         ed \
+        file \
         flex \
         gcc \
         gcc-c++ \
+        gdb \
         glibc-langpack-en \
         glibc-locale-source \
         initscripts \

--- a/images/docker/cbdb/test/rocky8/Dockerfile
+++ b/images/docker/cbdb/test/rocky8/Dockerfile
@@ -77,6 +77,8 @@ ENV LANG=en_US.UTF-8
 # to reduce the image size.
 # --------------------------------------------------------------------
 RUN dnf install -y \
+        file \
+        gdb \
         glibc-locale-source \
         make \
         openssh \

--- a/images/docker/cbdb/test/rocky9/Dockerfile
+++ b/images/docker/cbdb/test/rocky9/Dockerfile
@@ -77,6 +77,8 @@ ENV LANG=en_US.UTF-8
 # to reduce the image size.
 # --------------------------------------------------------------------
 RUN dnf install -y \
+        file \
+        gdb \
         glibc-locale-source \
         make \
         openssh \


### PR DESCRIPTION
We are adding core file analysis to the cloudberry CI. The packages (gdb and file) are used as part of that process.