### PR TITLE
Add new Cloudberry dependency

### DIFF
--- a/images/docker/cbdb/build/rocky8/Dockerfile
+++ b/images/docker/cbdb/build/rocky8/Dockerfile
@@ -100,6 +100,7 @@ RUN dnf makecache && \
         libuuid-devel \
         libxml2-devel \
         libzstd-devel \
+        lsof \
         lz4 \
         lz4-devel \
         make \

--- a/images/docker/cbdb/build/rocky9/Dockerfile
+++ b/images/docker/cbdb/build/rocky9/Dockerfile
@@ -94,6 +94,7 @@ RUN dnf makecache && \
         initscripts \
         iproute \
         less \
+        lsof \
         m4 \
         net-tools \
         openssh-clients \


### PR DESCRIPTION
commit 44a2d28beef3225517804c41b87636ff186da381
Author: Chen Mulong <chenmulong@gmail.com>
Date:   Fri Jun 9 09:50:55 2023 +0800

    Remove psutil usage from regress tests (#15711)

    psutil is not a dependency of plpython, thus we cannot assume it exists
    when running regress test. We are going to use different python versions
    for management utilities and plpython in the future release, and psutil
    won't exist anymore while running regress tests.

    - Rewrite teh motion_socket tests with 'lsof', which is a explicit dependency of greenplum.