### PR TITLE
Add protobuf-devel to Dockerfiles for Rocky 8 and 9 builds

### DIFF
--- a/images/docker/cbdb/build/rocky8/Dockerfile
+++ b/images/docker/cbdb/build/rocky8/Dockerfile
@@ -132,7 +132,8 @@ RUN dnf makecache && \
     dnf install -y -d0 --enablerepo=devel \
         libuv-devel \
         libyaml-devel \
-        perl-IPC-Run && \
+        perl-IPC-Run \
+        protobuf-devel && \
     dnf clean all && \
     cd && XERCES_LATEST_RELEASE=3.3.0 && \
     wget -nv "https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-${XERCES_LATEST_RELEASE}.tar.gz" && \

--- a/images/docker/cbdb/build/rocky9/Dockerfile
+++ b/images/docker/cbdb/build/rocky9/Dockerfile
@@ -136,7 +136,8 @@ RUN dnf makecache && \
     dnf install -y --enablerepo=crb \
         libuv-devel \
         libyaml-devel \
-        perl-IPC-Run && \
+        perl-IPC-Run \
+        protobuf-devel && \
     dnf clean all && \
     cd && XERCES_LATEST_RELEASE=3.3.0 && \
     wget -nv "https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-${XERCES_LATEST_RELEASE}.tar.gz" && \


### PR DESCRIPTION
This ensures protobuf headers and libraries are available during build, which may be required for dependencies or future compilation steps.