### PR TITLE
Install the Python packages from the distro's repo

### DIFF
--- a/build_automation/cloudberry/scripts/configure-cloudberry.sh
+++ b/build_automation/cloudberry/scripts/configure-cloudberry.sh
@@ -145,7 +145,6 @@ execute_cmd ./configure --prefix=/usr/local/cloudberry-db \
             --with-perl \
             --with-pgport=5432 \
             --with-python \
-            --with-pythonsrc-ext \
             --with-ssl=openssl \
             --with-openssl \
             --with-uuid=e2fs \

--- a/images/docker/cbdb/build/rocky8/Dockerfile
+++ b/images/docker/cbdb/build/rocky8/Dockerfile
@@ -119,6 +119,9 @@ RUN dnf makecache && \
         procps-ng \
         python3 \
         python3-devel \
+        python3-psutil \
+        python3-psycopg2 \
+        python3-pyyaml \
         readline-devel \
         rsync \
         sshpass \

--- a/images/docker/cbdb/build/rocky9/Dockerfile
+++ b/images/docker/cbdb/build/rocky9/Dockerfile
@@ -130,6 +130,9 @@ RUN dnf makecache && \
         perl-Test-Simple \
         perl-core \
         python3-devel \
+        python3-psutil \
+        python3-psycopg2 \
+        python3-pyyaml \
         python3-pytest \
         readline-devel \
         zlib-devel && \


### PR DESCRIPTION
Cherrypicks the Python dependencies changes from Greenplum to Cloudberry in this PR: https://github.com/apache/cloudberry/pull/1067.

So we need to update the configure script and install the Python dependencies from the distro's repos.