### PR TITLE
Use additional flag for profiling

### DIFF
--- a/build_automation/cloudberry/scripts/configure-cloudberry.sh
+++ b/build_automation/cloudberry/scripts/configure-cloudberry.sh
@@ -56,9 +56,13 @@
 #
 #                 When true, enables:
 #                   --enable-debug
-#                   --enable-profiling
 #                   --enable-cassert
 #                   --enable-debug-extensions
+#
+#   ENABLE_PROFILING - Enable profiling options (default is false)
+#
+#                 When true, enables:
+#                   --enable-profiling
 #
 # Prerequisites:
 #   - System dependencies must be installed:
@@ -119,9 +123,13 @@ CONFIGURE_DEBUG_OPTS=""
 
 if [ "${ENABLE_DEBUG:-false}" = "true" ]; then
     CONFIGURE_DEBUG_OPTS="--enable-debug \
-                          --enable-profiling \
                           --enable-cassert \
                           --enable-debug-extensions"
+fi
+
+CONFIGURE_PROFILING_OPTS=""
+if [ "${ENABLE_PROFILING:-false}" = "true" ]; then
+    CONFIGURE_PROFILING_OPTS="--enable-profiling"
 fi
 
 # Configure build
@@ -136,6 +144,7 @@ execute_cmd ./configure --prefix=/usr/local/cloudberry-db \
             --enable-pxf \
             --enable-tap-tests \
             ${CONFIGURE_DEBUG_OPTS} \
+	    ${CONFIGURE_PROFILING_OPTS} \
             --with-gssapi \
             --with-ldap \
             --with-libxml \


### PR DESCRIPTION
``--enable-profiling`` instructs gcc to add profiling sampling to the compiled binaries. It also generates a gmon.out file, which is a sample file commonly used by the https://en.wikipedia.org/wiki/GProf utility. 

The issue with gmon.out is that it consumes gigabytes of space and is not needed for pg_regress tests. It is a stat for manual gprof analysis. 

Let's disable it by default.

Currently it is used in the https://github.com/apache/cloudberry/blob/main/.github/workflows/build-dbg-cloudberry.yml workflow.