### PR TITLE
Update dorny/paths-filter version tag to commit

### DIFF
--- a/.github/workflows/docker-cbdb-build-containers.yml
+++ b/.github/workflows/docker-cbdb-build-containers.yml
@@ -96,7 +96,7 @@ jobs:
       # This prevents unnecessary builds if only one platform was modified
       - name: Determine if platform changed
         id: platform-filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         with:
           filters: |
             rocky8:

--- a/.github/workflows/docker-cbdb-test-containers.yml
+++ b/.github/workflows/docker-cbdb-test-containers.yml
@@ -80,7 +80,7 @@ jobs:
       # Determine if the current platform's files have changed
       - name: Determine if platform changed
         id: platform-filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         with:
           filters: |
             rocky8:


### PR DESCRIPTION
fix #20 

---

As reported in issue #20, dorny/paths-filter@v3 is not allowed to be
    used in the Apache repos. So we need to change the version tag to the
    git commit to use it.

The commit maps v3.0.2 - https://github.com/dorny/paths-filter/commit/de90cc6fb38fc0963ad72b210f1f284cd68cea36

See: https://issues.apache.org/jira/browse/INFRA-26729