### PR TITLE
Update gcc/g++ settings for PAX on RockyLinux 8

### DIFF
--- a/images/docker/cbdb/build/rocky8/Dockerfile
+++ b/images/docker/cbdb/build/rocky8/Dockerfile
@@ -87,8 +87,8 @@ RUN dnf makecache && \
         diffutils \
         file \
         flex \
-        gcc-toolset-11-gcc \
-        gcc-toolset-11-gcc-c++ \
+        gcc \
+        gcc-c++ \
         gdb \
         glibc-langpack-en \
         glibc-locale-source \
@@ -136,8 +136,6 @@ RUN dnf makecache && \
         perl-IPC-Run \
         protobuf-devel && \
     dnf clean all && rm -rf /var/cache/dnf/* && \
-    echo "source /opt/rh/gcc-toolset-11/enable" >> /etc/profile.d/gcc.sh && \
-    source /etc/profile.d/gcc.sh && \
     cd && XERCES_LATEST_RELEASE=3.3.0 && \
     wget -nv "https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-${XERCES_LATEST_RELEASE}.tar.gz" && \
     echo "$(curl -sL https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-${XERCES_LATEST_RELEASE}.tar.gz.sha256)" | sha256sum -c - && \


### PR DESCRIPTION
Cloudberry can now be built with PAX support using the default GCC/G++
toolchain on Rocky Linux 8. There is no longer a need to upgrade
GCC/G++.

The default GCC/G++ version on Rocky Linux 8 are:
 - gcc 8.5.0
 - g++ 8.5.0

See PR: https://github.com/apache/cloudberry/pull/1165