### PR TITLE
Add libssh2-devel package for gpfdist new feature

### DIFF
--- a/images/docker/cbdb/build/rocky8/Dockerfile
+++ b/images/docker/cbdb/build/rocky8/Dockerfile
@@ -76,6 +76,7 @@ RUN dnf makecache && \
     dnf makecache && \
     dnf config-manager --disable epel && \
     dnf install -y -d0 --enablerepo=epel \
+        libssh2-devel \
         the_silver_searcher \
         htop && \
     dnf install -y -d0 \

--- a/images/docker/cbdb/build/rocky9/Dockerfile
+++ b/images/docker/cbdb/build/rocky9/Dockerfile
@@ -77,6 +77,7 @@ RUN dnf makecache && \
     dnf makecache && \
     dnf config-manager --disable epel && \
     dnf install -y --enablerepo=epel \
+        libssh2-devel \
         the_silver_searcher \
         bat \
         htop && \


### PR DESCRIPTION
libssh2-devel is introduced as a dependency package for the new feature in the PR https://github.com/apache/cloudberry/pull/1226.